### PR TITLE
Minor language fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 The purpose of the *Interoperability Specification Profile*, or *INSPEC* in short, is to promote interoperability through reuse of classes, properties and concepts across specifications. By reuse we mean using the same identifiers and therefore share the formal definitions, not just names. The intention is to allow the information models of specifications to form a larger network of definitions that can act as a basis for interoperability, improved quality, quicker development time and a supportive community with a shared knowledge base.
 
-The requirements of interoperable specification are expressed in the form of a profile, this means that the requirements are expressed as special uses / pattern of something existing rather than introducing something entirely new. Absolute requirements are expressed with MUST / MUST NOT, strong requirments with SHOULD / SHOULD NOT and finally MAY for weaker recommendations, see [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) for a longer treatment.
+The requirements of interoperable specification are expressed in the form of a profile, this means that the requirements are expressed as special uses / pattern of something existing rather than introducing something entirely new. Absolute requirements are expressed with MUST / MUST NOT, strong requirements with SHOULD / SHOULD NOT and finally MAY for weaker recommendations, see [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt) for a longer treatment.
 
 ## Short introduction
 
 A specification has historically often been seen as a specification document containing a mixture of background, motivation and more formal descriptions. A more modern way of looking at a specification is that it is a package of resources, some targeted towards human consumption while others towards processing by machines.
 
-At the core of most specification is an **information model** that describes how data is expressed. An information model can be described informally in a specification document but can also be expressed more formally using a modelling language such as UML, ER-diagrams, OWL or RDFS. The information model is often expressed in terms of **classes**, **properties** (attributes and relations) as well as **concepts**. In addition, there is nearly always a visualization, typically in the form of a UML class **diagram**.
+At the core of most specification is an **information model** that describes how data is expressed. An information model can be described informally in a specification document but can also be expressed more formally using a modeling language such as UML, ER-diagrams, OWL or RDFS. The information model is often expressed in terms of **classes**, **properties** (attributes and relations) as well as **concepts**. In addition, there is nearly always a visualization, typically in the form of a UML class **diagram**.
 
 A consequence of aiming for reuse of classes and properties is that they need to defined more loosely so they are flexible enough to be combined in different ways. For instance, the property `publisher` from the Dublin Core Metadata Initiative is described in a sufficient generic manner so it can be applied to both a `Text` and a `Dataset`. Consequently, there is a need to describe how they are combined in a specific setting, we refer to this as an **application profile**.
 
@@ -51,7 +51,7 @@ This profile does note take a stance on specific tools.
 
 ## Process for the development of the profile
 
-The interoperable specification profile is beeing developed as part of the metadata working group within ENA, Swedish digital infrastructure. 
+The interoperable specification profile is being developed as part of the metadata working group within ENA, Swedish digital infrastructure.
 The work is led by [Agency for Digital Government (Digg)](https://www.digg.se).
 
 For more details, see the [separate page with planned meetings, slides, notes, reference group etc.](process/index.md).
@@ -59,6 +59,6 @@ For more details, see the [separate page with planned meetings, slides, notes, r
 ## How to give feedback
 
 - Create and comment on issues in Github
-- Create pull-requests for concreate changes
+- Create pull-requests for concrete changes
 - Participate in the reference group meetings
 - Send mail to [info@digg.se](mailto:info@digg.se) for other questions or to reach out to get involved

--- a/docs/ap.md
+++ b/docs/ap.md
@@ -174,6 +174,7 @@ Now we want to extend the book profile with the publisher restricted to organiza
     ex:ps-publisher2 a sh:PropertyShape
       sh:path dcterms:publisher ;
       sh:class foaf:Organization ;
+      inspec:refines ex:ps-publisher;
       sh:and ( ex:ps-publisher ) .
 
 ## Node shape variant - provide variants of node shapes ([Rule AP-10](rules.md#ap10))
@@ -320,3 +321,5 @@ However, there are situations where the same property is reused on the same node
         sh:path foaf:topic_interests ;
         sh:nodeKind sh:URI ;
         sh:pattern "^http://example.com/computer_science/.*$";
+
+Read the chapter "[Using the same property for different purposes](property-reuse.md)" for a longer background and recommendations on when it is suitable to reuse properties in this manner.

--- a/docs/ap.md
+++ b/docs/ap.md
@@ -2,14 +2,14 @@
 
 The purpose of an application profile is to clarify in more detail on how to reuse classes, properties and concepts in new settings.
 The needs can to a large extent be covered by the SHACL Shapes Constraint Language, a language for validating RDF graphs against a set of conditions.
-However, SHACL is too flexibile for the use case of application profiles, hence we define the SHACL-INSPEC to capture the specific requirements / constraints that needs to be met when using SHACL for expressing application profiles. (A side note is that SHACL-INSPEC itself is formally an application profile of SHACL and could therefore be expressed with the help of itself. In time this will perhaps be done, but for now we ignore this as it most likely cause more confusion rather than help to clarify.)
+However, SHACL is too flexible for the use case of application profiles, hence we define the SHACL-INSPEC to capture the specific requirements / constraints that needs to be met when using SHACL for expressing application profiles. (A side note is that SHACL-INSPEC itself is formally an application profile of SHACL and could therefore be expressed with the help of itself. In time this will perhaps be done, but for now we ignore this as it most likely cause more confusion rather than help to clarify.)
 
 ## Glossary
 Let's clarify the words we are using in SHACL-INSPEC:
 
 * Entity - a distinct thing/resource/instance/individual described in a dataset
 * Property - a specific characteristic of an entity
-* Class - a set of entites of the same kind / character / category
+* Class - a set of entities of the same kind / character / category
 * Data graph - data about an entity expressed as RDF
 * Node - a reference to a entity in a data graph
 * Triple - a fact/statement about an entity (via a node) in a data graph
@@ -37,7 +37,7 @@ The following information MUST be provided for an application profile resource:
 * A list of main node shapes indicated via the property `dcterms:hasPart`
 * A list of supportive node shapes indicated via the property `dcterms:references`
 * A list of all property shapes referred to from main or supportive node shapes via the property `dcterms:references`
-* A list of all classes and properties used in the application profile must be indicated via the property `dcterms:requires` (the foundational classes from SKOS and RDFS should be exluded)
+* A list of all classes and properties used in the application profile must be indicated via the property `dcterms:requires` (the foundational classes from SKOS and RDFS should be excluded)
 
 The following information MAY be provided:
 
@@ -86,13 +86,13 @@ The following information MUST be provided for a property shape:
 The following information MAY be provided:
 
 * Express cardinality by:
-  * `sh:minCount` "1"^^xsd:integer for mandatory
-  * `sh:minCount` "0"^^xsd:integer for preferred
+  * `sh:minCount "1"^^xsd:integer` for mandatory
+  * `sh:minCount "0"^^xsd:integer` for preferred
   * `sh:minCount "-1"^^xsd:integer` for optional (or, if left out it should be interpreted as -1)
   * `sh:maxCount "N"^^xsd:integer` for a maximum cardinality of `N`
 * A description / definition expressed via the property `sh:description`
 * A usage note expressed via the property `vann:usageNote`
-* That a datatype is required on literals by using `sh:datatype` (if several datatypes are allowed, a construction with several property shapes with individual `sh:datatype` joined togehter via `sh:or` is neccessary)
+* That a datatype is required on literals by using `sh:datatype` (if several datatypes are allowed, a construction with several property shapes with individual `sh:datatype` joined together via `sh:or` is necessary)
 * That a language is required on literals by setting `sh:datatype` to `rdf:langString`
 * Constraints on which literals that is allowed by:
     * An explicit list by using `sh:in` pointing to a SHACL list
@@ -102,7 +102,7 @@ The following information MAY be provided:
     * A constraining URI pattern expressed by `sh:pattern` (Regular expression)
     * Constrain to concepts in a terminology (see [section below](#terminology))
     * Constrain to concepts in a concept collection (see section below (TODO))
-    * Constrain to instances of a class by `sh:class` (if instances from several classes are allowed, a construction with several property shapes with `sh:class` joined togehter via a `sh:or` is neccessary)
+    * Constrain to instances of a class by `sh:class` (if instances from several classes are allowed, a construction with several property shapes with `sh:class` joined together via a `sh:or` is necessary)
 * A reference to another property shape it:
   * "refines" via `inspec:refines` AND `sh:and` with a SHACL list containing the refined property shape (see [section on property refinement](#property_refinement)), OR
   * "is variant of" via the `inspec:variant` property (see [section on property variants](#property_variant))
@@ -110,7 +110,7 @@ The following information MAY be provided:
 ## Property shape refinement - how to refine/specialize/inherit property shapes ([Rule AP-7](rules.md#ap7))
 <a id="property_refinement"></a>
 
-SHACL allows shapes to be combined via `sh:and`. This can be used to specialize an existing shapes with additional constraints or further restricting. We also express the relation directly to the property shape being refined via the `inspec:refines`, this is due to the `sh:and` construction is a bit obscure and can be hard to distinguish from other expressions when querying. E.g. consider the following property shape for the property `dcterms:publisher` where the range is `foaf:Agent`.
+SHACL allows shapes to be combined via `sh:and`. This can be used to specialize an existing shapes with additional constraints or further restricting. We also express the relation directly to the property shape being refined via the `inspec:refines`, this is due to the `sh:and` construction being a bit obscure and it can be hard to distinguish from other expressions when querying. E.g. consider the following property shape for the property `dcterms:publisher` where the range is `foaf:Agent`.
 
     ex:ps-publisher a sh:PropertyShape ;
       sh:label "Publisher" ;
@@ -207,7 +207,7 @@ Now to provide a variant of the book profile we use the `inspec:variant` propert
       sh:path dcterms:publisher ;
       sh:nodeKind sh:URI ;
       sh:class foaf:Agent ;
-      dcterms:isVersionOf ex:ps-publisher .
+      inspec:variant ex:ps-publisher .
 
 ## Providing order of property shapes
 <a id="order"></a>
@@ -240,14 +240,14 @@ If you are reusing property shapes in new settings (e.g. in specialization of no
 To change the order so the `dcterms:identifier` is at the top you can make a minimal specialization of that property shape with another `sh:order`:
 
     ex:ns2 a sh:NodeShape ;
-      sh:label "Book 2" ;
+      sh:label "Book 2"@en ;
       sh:property [
           sh:path dcterms:identifier ;
           sh:order "0.5"^^xsd:decimal ;
           sh:and ( ex:ps-identifier ) .
       ], ex:ps-title.
 
-Note that you have to repeat the `sh:path` due to SHACL rules. We have chosen to not give the new property shape a URI since it does not provide any additional value beyond the order, which is specific to the node shape. This is possible since it does not fall under the AP-4 rule since `sh:and` is excluded, `sh:path` is not a constraint and an `sh:order` is a characteristic (i.e. a non-validating property).
+Note that you have to repeat the `sh:path` due to SHACL rules. We have chosen to not give the new property shape a URI since it does not provide any additional value beyond the order, which is specific to the node shape. This is possible since it does not fall under the AP-3 rule since `sh:and` is excluded, `sh:path` is not a constraint and an `sh:order` is a characteristic (i.e. a non-validating property).
 
 ## Restricting to concepts in a terminology
 <a id="terminology"></a>
@@ -274,7 +274,7 @@ ex:ps1 a sh:propetyShape ;
     ]
 ```
 
-The reason we se the `sh:severity` to `sh:Info` is that if we try validate a data graph against this SHACL expression we do not always expect to have the entire terminology loaded with `rdf:type` and `skos:inScheme` triples for all concepts. In this case we instead rely on the `sh:pattern` to give us a more syntactical indication that the URI in the data graph corresponds to a correct concept. The expression with `rdf:type` and `skos:inScheme` (1 & 2 above) is provided to allow us to both detect that this is in fact a terminology when we render the specification and a more correct way to search for the intended concepts.
+The reason we set the `sh:severity` to `sh:Info` is that if we try validate a data graph against this SHACL expression we do not always expect to have the entire terminology loaded with `rdf:type` and `skos:inScheme` triples for all concepts. In this case we instead rely on the `sh:pattern` to give us a more syntactical indication that the URI in the data graph corresponds to a correct concept. The expression with `rdf:type` and `skos:inScheme` (1 & 2 above) is provided to allow us to both detect that this is in fact a terminology when we render the specification and a more correct way to search for the intended concepts.
 
 TODO Concept Collections
 

--- a/docs/bootstrapping.md
+++ b/docs/bootstrapping.md
@@ -1,8 +1,8 @@
 # Bootstrapping specifications
 
-To make intoperable specifications work we need a clear way to identify the different parts. This is achieved by indicating the character of various resources by saying that they conform to a specification. Note that these bootstrapping specifications need not be interoperable specifications in themselves (but it does not hurt if they are).
+To make interoperable specifications work we need a clear way to identify the different parts. This is achieved by indicating the character of various resources by saying that they conform to a specification. Note that these bootstrapping specifications need not be interoperable specifications in themselves (but it does not hurt if they are).
 
-The bootstrapping specifications have not yet recieved a stable namespace, but a good candidate may be:
+The bootstrapping specifications have not yet received a stable namespace, but a good candidate may be:
 
 namespace | expansion
 --- | ---

--- a/docs/example.md
+++ b/docs/example.md
@@ -13,7 +13,6 @@ The publisher should be typed as a person, have a name, an email that is recomme
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix dtheme: <http://publications.europa.eu/resource/authority/data-theme/>
 @prefix prof: <http://www.w3.org/ns/dx/prof/> .
 @prefix dtheme: <http://publications.europa.eu/resource/authority/data-theme/> .
 @prefix dmitype: <http://purl.org/dc/dcmitype/> .

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -73,17 +73,17 @@ SHACL-INSPEC builds on top of the SHACL specification by providing additional re
 
 ><a id="ap5"></a> **Rule AP-5:** Reusable node shapes are considered **main** if they have a target declaration, otherwise they are considered **supportive**
 
-><a id="ap6"></a> **Rule AP-6:** All reusable node shapes as well all property shapes pointed to from those MUST provide a label and MAY also provide a definition and a usage note
+><a id="ap6"></a> **Rule AP-6:** All reusable node shapes, as well as all property shapes pointed to from those, MUST provide a label and MAY also provide a definition and a usage note
 
-><a id="ap7"></a> **Rule AP-7:** A property shapes MAY express that it **refines** a reusable property shape via both the `inspec:refines` property as well as via a `sh:and` construct, the latter to be compatible with normal SHACL validation.
+><a id="ap7"></a> **Rule AP-7:** A property shape MAY express that it **refines** a reusable property shape via both the `inspec:refines` property as well as via a `sh:and` construct, the latter to be compatible with normal SHACL validation.
 
-><a id="ap8"></a> **Rule AP-8:** A property shapes MAY express that it is a **variant** of a reusable property shape via the `inspec:variant` property
+><a id="ap8"></a> **Rule AP-8:** A property shape MAY express that it is a **variant** of a reusable property shape via the `inspec:variant` property
 
 ><a id="ap9"></a> **Rule AP-9:** A node shape *B* MAY express that it **refines** a reusable node shape *A* via the `inspec:refines` property only if for every property shape *X* in *A* either *X* or a refinement *Y* of *X* is in *B*. 
 
 ><a id="ap10"></a> **Rule AP-10:** A node shape *B* MAY express that it is a **variant** of a reusable node shape *A* via the `inspec:variant` property only if for every property shape *X* in *A* either *X* or *Y* is in *B* where *Y* is a refinement or a variant of *X*. At least one of the property shapes must be a variant and not a refinement.
 
-><a id="ap11"></a> **Rule AP-11:** An applicatin profile *B* MAY express that it is a **subprofile of** of an application profile *A* via the `prof:isProfileOf` property only if for every node shape *X* in *A* there is a refined node shape *Y* in *B*.
+><a id="ap11"></a> **Rule AP-11:** An application profile *B* MAY express that it is a **subprofile of** of an application profile *A* via the `prof:isProfileOf` property only if for every node shape *X* in *A* there is a refined node shape *Y* in *B*.
 
 ><a id="ap12"></a> **Rule AP-12:** An application profile *B* MAY express that it is a **variant** of a application profile *A* via the `inspec:variant` property only if for every node shape *X* in *A* there is a variant or refined node shape *Y* in *B*, at least one of the node shapes must be a variant and not a refinement.
 


### PR DESCRIPTION
# Pull Request Description

Most changes are trivial typos with these exceptions:
* In one case it's a spelling change form EN-GB to EN-US to keep in line with rest of the document.
* AP cardinality rules: Standardised the cardinality expressions to include the value string in the inline code block. This could also have been standardised by excluding the values in all four cases.
* Added commas to rule AP-6 to clarify what "those" refers to.
* Added language to string in an example, to minimise difference to previous example.
* Removed duplicate `@prefix` from example

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
