### PR TITLE
add vocabulary

### DIFF
--- a/vocabulary.rdf
+++ b/vocabulary.rdf
@@ -30,7 +30,7 @@
   <rdfs:Class rdf:about="http://w3id.org/inspec/SHACL">
     <rdfs:label xml:lang="en">SHACL</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/"/>
-    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the rules AP-1 — AP-10.</rdfs:comment>
+    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the rules AP-1 — AP-14.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/shacl"/>
   </rdfs:Class>
   <rdfs:Class rdf:about="http://w3id.org/inspec/SVG">

--- a/vocabulary.ttl
+++ b/vocabulary.ttl
@@ -32,7 +32,7 @@ inspec:SKOS a rdfs:Class ;
 inspec:SHACL a rdfs:Class ;
   rdfs:label "SHACL"@en ;
   rdfs:isDefinedBy inspec: ;
-  rdfs:comment "This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the rules AP-1 — AP-10."@en ;
+  rdfs:comment "This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the rules AP-1 — AP-14."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/shacl> .
 
 inspec:SVG a rdfs:Class ;


### PR DESCRIPTION
# Pull Request Description

This adds a formal vocabulary for INSPEC in the turtle and RDF/XML format.

For the domain/range of `inspec:variant` an `owl:unionOf` construction is used since multiple domain/range properties implies that the target must be an instance of all the classes.

Note that this is not updated with the numbering in PR #30 

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
