### PR TITLE
use w3id with a /datavoc/ structure

### DIFF
--- a/datavoc/README.md
+++ b/datavoc/README.md
@@ -1,0 +1,5 @@
+# INSPEC data vocabulary
+
+The INSPEC data vocabulary is provided in [Turtle](vocabulary.ttl) or [RDF/XML](vocabulary.rdf).
+
+For the full Profile see [INSPEC](../).

--- a/datavoc/vocabulary.rdf
+++ b/datavoc/vocabulary.rdf
@@ -4,10 +4,10 @@
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:owl="http://www.w3.org/2002/07/owl#"
 >
-  <rdfs:Class rdf:about="http://w3id.org/inspec/PROF">
+  <rdfs:Class rdf:about="http://w3id.org/inspec/datavoc/PROF">
     <rdfs:label xml:lang="en">PROF</rdfs:label>
     <rdfs:isDefinedBy>
-      <owl:Ontology rdf:about="http://w3id.org/inspec/">
+      <owl:Ontology rdf:about="http://w3id.org/inspec/datavoc/">
         <rdfs:label xml:lang="en">The Interoperable Specifications Profile (INSPEC) Vocabulary</rdfs:label>
         <rdfs:comment xml:lang="en">This vocabulary defines terms used in INSPEC.</rdfs:comment>
       </owl:Ontology>
@@ -15,33 +15,33 @@
     <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules INSPEC-1 — INSPEC-10.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/dx-prof/"/>
   </rdfs:Class>
-  <rdfs:Class rdf:about="http://w3id.org/inspec/RDFS">
+  <rdfs:Class rdf:about="http://w3id.org/inspec/datavoc/RDFS">
     <rdfs:label xml:lang="en">RDFS</rdfs:label>
-    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/"/>
+    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-6.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/rdf12-schema/"/>
   </rdfs:Class>
-  <rdfs:Class rdf:about="http://w3id.org/inspec/SKOS">
+  <rdfs:Class rdf:about="http://w3id.org/inspec/datavoc/SKOS">
     <rdfs:label xml:lang="en">SKOS</rdfs:label>
-    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/"/>
+    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-5.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/skos-reference/"/>
   </rdfs:Class>
-  <rdfs:Class rdf:about="http://w3id.org/inspec/SHACL">
+  <rdfs:Class rdf:about="http://w3id.org/inspec/datavoc/SHACL">
     <rdfs:label xml:lang="en">SHACL</rdfs:label>
-    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/"/>
+    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the rules AP-1 — AP-14.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/shacl"/>
   </rdfs:Class>
-  <rdfs:Class rdf:about="http://w3id.org/inspec/SVG">
+  <rdfs:Class rdf:about="http://w3id.org/inspec/datavoc/SVG">
     <rdfs:label xml:lang="en">SVG</rdfs:label>
-    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/"/>
+    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SVG used to capture an expression of diagrams for interoperable specifications. Corresponds to the rules SVG-1 — SVG-5.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/SVG11/"/>
   </rdfs:Class>
-  <rdf:Property rdf:about="http://w3id.org/inspec/variant">
+  <rdf:Property rdf:about="http://w3id.org/inspec/datavoc/variant">
     <rdfs:label xml:lang="en">variant</rdfs:label>
-    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/"/>
+    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">A shape or profile is a variant of another if it relaxes some of its constraints</rdfs:comment>
     <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
     <rdfs:domain>
@@ -61,9 +61,9 @@
       </rdf:Description>
     </rdfs:range>
   </rdf:Property>
-  <rdf:Property rdf:about="http://w3id.org/inspec/refines">
+  <rdf:Property rdf:about="http://w3id.org/inspec/datavoc/refines">
     <rdfs:label xml:lang="en">refines</rdfs:label>
-    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/"/>
+    <rdfs:isDefinedBy rdf:resource="http://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">A shape refines another by adding additional constraints to it</rdfs:comment>
     <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
     <rdfs:domain rdf:resource="http://www.w3.org/ns/shacl#Shape"/>

--- a/datavoc/vocabulary.ttl
+++ b/datavoc/vocabulary.ttl
@@ -5,7 +5,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 
-@prefix inspec: <http://w3id.org/inspec/> .
+@prefix inspec: <http://w3id.org/inspec/datavoc/> .
 
 inspec: a owl:Ontology ;
   rdfs:label "The Interoperable Specifications Profile (INSPEC) Vocabulary"@en ;

--- a/docs/bootstrapping.md
+++ b/docs/bootstrapping.md
@@ -6,7 +6,7 @@ The bootstrapping specifications have not yet received a stable namespace, but a
 
 namespace | expansion
 --- | ---
-inspec | <http://purl.org/inspec/>
+inspec | <http://w3id.org/inspec/datavoc/>
 
 ## inspec:PROF
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -15,7 +15,7 @@ The publisher should be typed as a person, have a name, an email that is recomme
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix prof: <http://www.w3.org/ns/dx/prof/> .
 @prefix dtheme: <http://publications.europa.eu/resource/authority/data-theme/> .
-@prefix inspec: <http://purl.org/inspec/> .
+@prefix inspec: <http://w3id.org/inspec/datavoc/> .
 
 ex:spec1 a prof:Profile ;
    dcterms:title "DocPub1.0 - document and publisher"@en ;


### PR DESCRIPTION
# Pull Request Description

Use w3id rather than purl.

Put the INSPEC data vocabulary under /datavoc/ to allow additional resources to be made available under the inspec namespace in the future.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
