### PR TITLE
set up Respec version of rules

### DIFF
--- a/datavoc/README.md
+++ b/datavoc/README.md
@@ -2,4 +2,4 @@
 
 The INSPEC data vocabulary is provided in [Turtle](vocabulary.ttl) or [RDF/XML](vocabulary.rdf).
 
-For the full Profile see [INSPEC](../).
+For the full Profile see [INSPEC](../docs/).

--- a/docs/config.js
+++ b/docs/config.js
@@ -3,7 +3,9 @@ var respecConfig = {
   shortName: "inspec",
   latestVersion: "http://w3id.org/inspec/specification",
   specStatus: "base",
-  lint: "true",
+  lint: {
+    "no-headingless-sections": false,
+  },
   editors: [
     {
       name: "Matthias Palmér",

--- a/docs/config.js
+++ b/docs/config.js
@@ -3,6 +3,7 @@ var respecConfig = {
   shortName: "inspec",
   latestVersion: "http://w3id.org/inspec/specification",
   specStatus: "base",
+  historyURI: null,
   lint: {
     "no-headingless-sections": false,
   },

--- a/docs/config.js
+++ b/docs/config.js
@@ -1,0 +1,92 @@
+var respecConfig = {
+  format: "markdown",
+  shortName: "inspec",
+  latestVersion: "http://w3id.org/inspec/specification",
+  specStatus: "base",
+  lint: "true",
+  editors: [
+    {
+      name: "Matthias Palmér",
+      url: "matthias@metasolutions.se",
+      company: "MetaSolutions",
+      companyURL: "https://metasolutions.se/",
+    },
+    {
+      name: "André Costa",
+      company: "MetaSolutions",
+      companyURL: "https://metasolutions.se/",
+    },
+  ],
+  github: "diggsweden/interoperable-specifications",
+  otherLinks: [
+    {
+      key: "On behalf of",
+      data: [{
+        value: "Swedish Agency for Digital Government",
+        href: "https://www.digg.se",
+        class: "p-org org h-org",
+      }]},
+    {
+      key: "Contributions from the reference group (in alphabetic order)",
+      data: [
+        {class: "editor p-author h-card vcard", value: "Andrew Mercer (Riksarkivet)"},
+        {class: "editor p-author h-card vcard", value: "Benny Lund (Bolagsverket)"},
+        {class: "editor p-author h-card vcard", value: "Caspar Almalander (Sveriges Kommuner och Regioner)"},
+        {class: "editor p-author h-card vcard", value: "Cilla Öhnfeldt (Naturvårdsverket)"},
+        {class: "editor p-author h-card vcard", value: "Erik Mossing (Bolagsverket)"},
+        {class: "editor p-author h-card vcard", value: "Fredrik Emanuelsson (Riksarkivet)"},
+        {class: "editor p-author h-card vcard", value: "Fredrik Klingwall (Kungliga biblioteket)"},
+        {class: "editor p-author h-card vcard", value: "Fredrik Persäter (Lantmäteriet)"},
+        {class: "editor p-author h-card vcard", value: "Jan Rydkvist (Statistikmyndigheten SCB)"},
+        {class: "editor p-author h-card vcard", value: "Johan Oelrich (Arbetsförmedlingen)"},
+        {class: "editor p-author h-card vcard", value: "Kristofer Gäfvert (Lantmäteriet)"},
+        {class: "editor p-author h-card vcard", value: "Lars Näslund (Trafikverket)"},
+        {class: "editor p-author h-card vcard", value: "Marcus Smith (Riksarkivet)"},
+        {class: "editor p-author h-card vcard", value: "Marjan Akhavan (E-hälsomyndigheten)"},
+        {class: "editor p-author h-card vcard", value: "Martin Brandhagen (Vetenskapsrådet)"},
+        {class: "editor p-author h-card vcard", value: "Matthias Palmér (Myndigheten för digital förvaltning)"},
+        {class: "editor p-author h-card vcard", value: "Mattias Ekhem (Myndigheten för digital förvaltning)"},
+        {class: "editor p-author h-card vcard", value: "Michalis Vassilas (Myndigheten för digital förvaltning)"},
+        {class: "editor p-author h-card vcard", value: "Olof Olsson (Svensk Nationell Datatjänst)"},
+        {class: "editor p-author h-card vcard", value: "Olov Johansson (Sveriges geologiska undersökning)"},
+        {class: "editor p-author h-card vcard", value: "Patrik Wahlgren (Statistikmyndigheten SCB)"},
+        {class: "editor p-author h-card vcard", value: "Per Wiklander (Vetenskapsrådet)"},
+        {class: "editor p-author h-card vcard", value: "Peter Israelsson (Myndigheten för digital förvaltning)"},
+        {class: "editor p-author h-card vcard", value: "Stefan Jakobsson (Svensk nationell datatjänst)"},
+        {class: "editor p-author h-card vcard", value: "Tomas Lindberg (Sveriges geologiska undersökning)"},
+        {class: "editor p-author h-card vcard", value: "Ulrika Domellöf Mattson (Myndigheten för digital förvaltning)"},
+      ]
+    },
+    {
+      key: "License",
+      data: [{
+        value: "CC-BY 4.0",
+        href: "http://creativecommons.org/licenses/by/4.0/",
+      }]
+    },
+  ],
+  // non-standard respec
+  title: "Interoperable Specifications Profile",
+  version: "1.0.0",
+  copyright: 'Copyright © 2025 <a href="https://www.digg.se">DIGG</a>.',
+  abstract: "The Interoperability Specification Profile aims to provide a mechanism for reusing parts of specifications when creating new specifications. It thus defines a specification as a container that consists of one or more resources each given URIs and described using RDF.",
+}
+
+// override some W3C settings and move content out of html
+function overrideTitle(conf) {
+  document.title = `${conf.title} - version ${conf.version}`;
+}
+
+function setCopyright(conf) {
+  const existingCopyright = document.querySelector(".copyright");
+  existingCopyright.innerHTML = `${conf.copyright}`;
+}
+
+function setAbstract(conf) {
+  const existingAbstract = document.getElementById("abstract");
+  existingAbstract.innerHTML = `${conf.abstract}`;
+}
+
+overrideTitle(respecConfig);
+setCopyright(respecConfig);
+setAbstract(respecConfig);

--- a/docs/config.js
+++ b/docs/config.js
@@ -72,7 +72,7 @@ var respecConfig = {
   title: "Interoperable Specifications Profile",
   version: "1.0.0",
   copyright: 'Copyright © 2025 <a href="https://www.digg.se">DIGG</a>.',
-  abstract: "The Interoperability Specification Profile aims to provide a mechanism for reusing parts of specifications when creating new specifications. It thus defines a specification as a container that consists of one or more resources each given URIs and described using RDF.",
+  abstract: "A specification describes how data should be expressed and understood. The Interoperable Specifications Profile (INSPEC) has been developed to ensure that specifications are interoperable, reusable, and machine-readable. It follows a more modern approach, viewing a specification as a package of resources or components, some intended for human consumption and others for machine processing — resources, described using RDF, that are pre-defined to facilitate both semantic and technical interoperability.",
 }
 
 // override some W3C settings and move content out of html

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="color-scheme" content="light dark">
+    <title>Interoperable Specifications Profile</title>
+    <script class="remove" src="config.js" defer></script>
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c" defer></script>
+    <style>
+      .removeOnSave {
+        display: none !important;
+      }
+    </style>
+</head>
+<body>
+<p class="copyright"></p>
+<section id="abstract"></section>
+
+<section data-include="./rules.md" data-include-format='markdown'></section>
+
+<section id="conformance"></section>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,6 +6,7 @@
     <title>Interoperable Specifications Profile</title>
     <script class="remove" src="config.js" defer></script>
     <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c" defer></script>
+    <script class="remove" src="tweaks.js" defer></script>
     <style>
       .removeOnSave {
         display: none !important;

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -14,104 +14,106 @@ The rules for interoperable specifications are divided into five parts:
 
 For a specification to be considered a interoperable specification the following must apply:
 
-><a id="inspec1"></a> **Rule INSPEC-1:** The "interoperable specification resource" and its parts MUST have URIs and be described with PROF, the interoperable specification resource must be typed as `prof:Profile` or `dcterms:Standard` and have a `dct:conformsTo` point to `inspec:PROF`
+><span id="inspec1"></span> **Rule INSPEC-1:** The "interoperable specification resource" and its parts MUST have URIs and be described with PROF, the interoperable specification resource must be typed as `prof:Profile` or `dcterms:Standard` and have a `dct:conformsTo` point to `inspec:PROF`
 
-><a id="inspec2"></a> **Rule INSPEC-2:** An interoperable specification part MAY be a data vocabulary, a terminology, an application profile or a diagram. Other parts may exist but have no prescribed meaning by the interoperable specification profile.
+><span id="inspec2"></span> **Rule INSPEC-2:** An interoperable specification part MAY be a data vocabulary, a terminology, an application profile or a diagram. Other parts may exist but have no prescribed meaning by the interoperable specification profile.
 
-><a id="inspec3"></a> **Rule INSPEC-3:** Each data vocabulary MUST be detected by `dcterms:conformsTo` pointing to `inspec:RDFS` and MUST be possible to interpret as RDFS-INSPEC.
+><span id="inspec3"></span> **Rule INSPEC-3:** Each data vocabulary MUST be detected by `dcterms:conformsTo` pointing to `inspec:RDFS` and MUST be possible to interpret as RDFS-INSPEC.
 
-><a id="inspec4"></a> **Rule INSPEC-4:** Each terminology MUST be detected by `dcterms:conformsTo` pointing to `inspec:SKOS` and MUST be possible to interpret as SKOS-INSPEC.
+><span id="inspec4"></span> **Rule INSPEC-4:** Each terminology MUST be detected by `dcterms:conformsTo` pointing to `inspec:SKOS` and MUST be possible to interpret as SKOS-INSPEC.
 
-><a id="inspec5"></a> **Rule INSPEC-5:** Each application profile MUST be detected by `dct:conformsTo` pointing to `inspec:SHACL` and MUST be possible to interpret as SHACL-INSPEC
+><span id="inspec5"></span> **Rule INSPEC-5:** Each application profile MUST be detected by `dct:conformsTo` pointing to `inspec:SHACL` and MUST be possible to interpret as SHACL-INSPEC
 
-><a id="inspec6"></a> **Rule INSPEC-6:** A diagram MUST be detected by `dct:conformsTo` property pointing to `inspec:SVG` and MUST follow SVG-INSPEC
+><span id="inspec6"></span> **Rule INSPEC-6:** A diagram MUST be detected by `dct:conformsTo` property pointing to `inspec:SVG` and MUST follow SVG-INSPEC
 
-><a id="inspec7"></a> **Rule INSPEC-7:** A **foundational** interoperable specification MUST contain at least one data vocabulary or one terminology, MUST NOT contain an application profile and MUST be typed as `dcterms:Standard`
+><span id="inspec7"></span> **Rule INSPEC-7:** A **foundational** interoperable specification MUST contain at least one data vocabulary or one terminology, MUST NOT contain an application profile and MUST be typed as `dcterms:Standard`
 
-><a id="inspec8"></a> **Rule INSPEC-8:** A **profile** interoperable specification MUST contain at least one data vocabulary, at least one application profile and MUST be typed as `prof:Profile`
+><span id="inspec8"></span> **Rule INSPEC-8:** A **profile** interoperable specification MUST contain at least one data vocabulary, at least one application profile and MUST be typed as `prof:Profile`
 
-><a id="inspec9"></a> **Rule INSPEC-9:** A profile interoperable specification MUST list all data vocabularies and terminologies it **uses** in the application profile explicitly as interoperable specification parts
+><span id="inspec9"></span> **Rule INSPEC-9:** A profile interoperable specification MUST list all data vocabularies and terminologies it **uses** in the application profile explicitly as interoperable specification parts
 
-><a id="inspec10"></a> **Rule INSPEC-10:** Data vocabularies and terminologies that are **reused** SHOULD indicate that by referring to the interoperable specification where they where introduced via the `prof:isInheritedFrom` property
+><span id="inspec10"></span> **Rule INSPEC-10:** Data vocabularies and terminologies that are **reused** SHOULD indicate that by referring to the interoperable specification where they where introduced via the `prof:isInheritedFrom` property
 
 ## Rules for data vocabularies - RDFS-INSPEC
 
 RDFS-INSPEC builds on top of the RDF Schema specification by providing the following additional restrictions:
 
-><a id="dv1"></a> **Rule DV-1:** A data vocabulary MUST be expressed in a single RDF Dataset.[^note1]
+><span id="dv1"></span> **Rule DV-1:** A data vocabulary MUST be expressed in a single RDF Dataset.<sup><a href="#fn1" id="fn1_1">[1]</a></sup>
 
-><a id="dv2"></a> **Rule DV-2:** There MUST be a single "data vocabulary resource" typed as `owl:Ontology` in the RDF Dataset
+><span id="dv2"></span> **Rule DV-2:** There MUST be a single "data vocabulary resource" typed as `owl:Ontology` in the RDF Dataset
 
-><a id="dv3"></a> **Rule DV-3:** All included classes and properties of the data vocabulary MUST point to the "data vocabulary resource" via the `rdfs:isDefinedBy` property
+><span id="dv3"></span> **Rule DV-3:** All included classes and properties of the data vocabulary MUST point to the "data vocabulary resource" via the `rdfs:isDefinedBy` property
 
-><a id="dv4"></a> **Rule DV-4:** All included classes and properties as well as the data vocabulary resource MUST have URIs
+><span id="dv4"></span> **Rule DV-4:** All included classes and properties as well as the data vocabulary resource MUST have URIs
 
-><a id="dv5"></a> **Rule DV-5:** Classes and properties from other vocabularies MAY BE included in the RDF Dataset, e.g. when being pointed to via `rdfs:subClassOf` and `rdfs:subProperty`, but MUST NOT point to the same "data vocabulary resource" via the `rdfs:isDefinedBy` property
+><span id="dv5"></span> **Rule DV-5:** Classes and properties from other vocabularies MAY BE included in the RDF Dataset, e.g. when being pointed to via `rdfs:subClassOf` and `rdfs:subProperty`, but MUST NOT point to the same "data vocabulary resource" via the `rdfs:isDefinedBy` property
 
-><a id="dv6"></a> **Rule DV-6:** The "data vocabulary resource" must be indicated via the `dcterms:requires` property from the "interoperable specification resource" (introduced in Rule INSPEC-1)
+><span id="dv6"></span> **Rule DV-6:** The "data vocabulary resource" must be indicated via the `dcterms:requires` property from the "interoperable specification resource" (introduced in Rule INSPEC-1)
 
 ## Rules for terminologies - SKOS-INSPEC
 
 SKOS-INSPEC builds on top of the SKOS specification by providing the following additional restrictions:
 
-><a id="te1"></a> **Rule TE-1:** A terminology MUST be expressed in a single RDF Dataset.[^note1]
+><span id="te1"></span> **Rule TE-1:** A terminology MUST be expressed in a single RDF Dataset.<sup><a href="#fn1" id="fn1_2">[1]</a></sup>
 
-><a id="te2"></a> **Rule TE-2:** There MUST be a single "terminology resource" with a URI typed as `skos:ConceptScheme` in the RDF Dataset
+><span id="te2"></span> **Rule TE-2:** There MUST be a single "terminology resource" with a URI typed as `skos:ConceptScheme` in the RDF Dataset
 
-><a id="te3"></a> **Rule TE-3:** All concepts and collections in the terminology MUST point to the "terminology resource" via the `skos:inScheme` property
+><span id="te3"></span> **Rule TE-3:** All concepts and collections in the terminology MUST point to the "terminology resource" via the `skos:inScheme` property
 
-><a id="te4"></a> **Rule TE-4:** All concepts, collections as well as the terminology resource MUST have URIs
+><span id="te4"></span> **Rule TE-4:** All concepts, collections as well as the terminology resource MUST have URIs
 
-><a id="te5"></a> **Rule TE-5:** The "terminology resource" must be indicated via the `dcterms:requires` property from the "interoperable specification resource" (introduced in Rule INSPEC-1)
+><span id="te5"></span> **Rule TE-5:** The "terminology resource" must be indicated via the `dcterms:requires` property from the "interoperable specification resource" (introduced in Rule INSPEC-1)
 
 ## Rules for application profiles - SHACL-INSPEC
 
 SHACL-INSPEC builds on top of the SHACL specification by providing additional restrictions. Since SHACL is a rich language the following rules does not cover all situations. For instance, the following rules does not indicate how to specify how to restrict to concepts from a specific terminology. For a more complete treatment see the [SHACL-INSPEC separate document](ap.md) for patterns on how to use the profile in various situations.
 
-><a id="ap1"></a> **Rule AP-1:** An application profile MUST be expressed in a single RDF Dataset[^note2]
+><span id="ap1"></span> **Rule AP-1:** An application profile MUST be expressed in a single RDF Dataset<sup><a href="#fn2" id="fn2_1">[2]</a></sup>
 
-><a id="ap2"></a> **Rule AP-2:** There MUST be a single "application profile resource" with a URI in the RDF Dataset AND it must be the same as the "interoperable specification resource" (introduced in Rule INSPEC-1)
+><span id="ap2"></span> **Rule AP-2:** There MUST be a single "application profile resource" with a URI in the RDF Dataset AND it must be the same as the "interoperable specification resource" (introduced in Rule INSPEC-1)
 
-><a id="ap3"></a> **Rule AP-3:** All property shapes with a severity of `sh:VIOLATION` and with at least one constraint (`sh:and` for specialization does not count) are considered **public** and they MUST have URIs and MUST also be pointed to from the application profile resource via the `dcterms:hasPart` property
+><span id="ap3"></span> **Rule AP-3:** All property shapes with a severity of `sh:VIOLATION` and with at least one constraint (`sh:and` for specialization does not count) are considered **public** and they MUST have URIs and MUST also be pointed to from the application profile resource via the `dcterms:hasPart` property
 
-><a id="ap4"></a> **Rule AP-4:** All node shapes with a severity of `sh:VIOLATION` are considered **public** and MUST have URIs and MUST also be pointed to from the application profile resource via the `dcterms:hasPart` property
+><span id="ap4"></span> **Rule AP-4:** All node shapes with a severity of `sh:VIOLATION` are considered **public** and MUST have URIs and MUST also be pointed to from the application profile resource via the `dcterms:hasPart` property
 
-><a id="ap5"></a> **Rule AP-5:** Public node shapes are considered **main** if they have a target declaration, otherwise they are considered **supportive**
+><span id="ap5"></span> **Rule AP-5:** Public node shapes are considered **main** if they have a target declaration, otherwise they are considered **supportive**
 
-><a id="ap6"></a> **Rule AP-6:** All public node shapes, as well as all property shapes pointed to from those, MUST provide a label and MAY also provide a definition and a usage note
+><span id="ap6"></span> **Rule AP-6:** All public node shapes, as well as all property shapes pointed to from those, MUST provide a label and MAY also provide a definition and a usage note
 
-><a id="ap7"></a> **Rule AP-7:** A property shape MAY express that it **refines** a public property shape via both the `inspec:refines` property as well as via a `sh:and` construct, the latter to be compatible with normal SHACL validation.
+><span id="ap7"></span> **Rule AP-7:** A property shape MAY express that it **refines** a public property shape via both the `inspec:refines` property as well as via a `sh:and` construct, the latter to be compatible with normal SHACL validation.
 
-><a id="ap8"></a> **Rule AP-8:** A property shape MAY express that it is a **variant** of a public property shape via the `inspec:variant` property
+><span id="ap8"></span> **Rule AP-8:** A property shape MAY express that it is a **variant** of a public property shape via the `inspec:variant` property
 
-><a id="ap9"></a> **Rule AP-9:** A node shape *B* MAY express that it **refines** a public node shape *A* via the `inspec:refines` property only if for every property shape *X* in *A* either *X* or a refinement *Y* of *X* is in *B*.
+><span id="ap9"></span> **Rule AP-9:** A node shape *B* MAY express that it **refines** a public node shape *A* via the `inspec:refines` property only if for every property shape *X* in *A* either *X* or a refinement *Y* of *X* is in *B*.
 
-><a id="ap10"></a> **Rule AP-10:** A node shape *B* MAY express that it is a **variant** of a public node shape *A* via the `inspec:variant` property only if for every property shape *X* in *A* either *X* or *Y* is in *B* where *Y* is a refinement or a variant of *X*. At least one of the property shapes must be a variant and not a refinement.
+><span id="ap10"></span> **Rule AP-10:** A node shape *B* MAY express that it is a **variant** of a public node shape *A* via the `inspec:variant` property only if for every property shape *X* in *A* either *X* or *Y* is in *B* where *Y* is a refinement or a variant of *X*. At least one of the property shapes must be a variant and not a refinement.
 
-><a id="ap11"></a> **Rule AP-11:** An application profile *B* MAY express that it is a **subprofile of** of an application profile *A* via the `prof:isProfileOf` property only if for every node shape *X* in *A* there is a refined node shape *Y* in *B*.
+><span id="ap11"></span> **Rule AP-11:** An application profile *B* MAY express that it is a **subprofile of** of an application profile *A* via the `prof:isProfileOf` property only if for every node shape *X* in *A* there is a refined node shape *Y* in *B*.
 
-><a id="ap12"></a> **Rule AP-12:** An application profile *B* MAY express that it is a **variant** of a application profile *A* via the `inspec:variant` property only if for every node shape *X* in *A* there is a variant or refined node shape *Y* in *B*, at least one of the node shapes must be a variant and not a refinement.
+><span id="ap12"></span> **Rule AP-12:** An application profile *B* MAY express that it is a **variant** of a application profile *A* via the `inspec:variant` property only if for every node shape *X* in *A* there is a variant or refined node shape *Y* in *B*, at least one of the node shapes must be a variant and not a refinement.
 
-><a id="ap13"></a> **Rule AP-13:** Shapes used for refinement or for variants MAY reside in other RDF Datasets as long as the dataset is pointed to via `owl:import` AND there is either a `prof:isProfileOf` or a `inspec:variant` relation between the application profile resources.
+><span id="ap13"></span> **Rule AP-13:** Shapes used for refinement or for variants MAY reside in other RDF Datasets as long as the dataset is pointed to via `owl:import` AND there is either a `prof:isProfileOf` or a `inspec:variant` relation between the application profile resources.
 
-><a id="ap14"></a> **Rule AP-14:** All classes, properties and terminologies referred to via shapes should be explicitly indicated via the `dcterms:requires` property from the "interoperable specification resource" (introduced in Rule INSPEC-1)
+><span id="ap14"></span> **Rule AP-14:** All classes, properties and terminologies referred to via shapes should be explicitly indicated via the `dcterms:requires` property from the "interoperable specification resource" (introduced in Rule INSPEC-1)
 
 ## Rules for diagrams - SVG-INSPEC
 
 SVG-INSPEC builds on top of SVG to provide a way to clarify whether objects in a diagram corresponds to an entity recognized in interoperable specifications, i.e. a class, a property, a node-shape, a property-shape, a concept, a terminology, or a concept collection. Also interoperable specifications or foundational specifications should be possible to indicate as well as diagrams and data vocabularies if they are included in the diagram. Note that there are no hard restrictions on the diagrammatic style used. Although it should be noted that it is good idea to choose a style that is well known like something akin to UML class diagrams.
 
-><a id="svg1"></a> **Rule SVG-1:** An element corresponding to an INSPEC entity MUST have a href pointing to it's URI. If the element corresponds to two things, e.g. both a class and a node-shape, the URI of the dominant one should be used.
+><span id="svg1"></span> **Rule SVG-1:** An element corresponding to an INSPEC entity MUST have a href pointing to it's URI. If the element corresponds to two things, e.g. both a class and a node-shape, the URI of the dominant one should be used.
 
-><a id="svg2"></a> **Rule SVG-2:** An element corresponding to an INSPEC entity MUST have a custom data attribute on the form `data-inspec-type="TYPE"` where TYPE is one of foundational, application-profile, diagram, data-vocabulary, class, property, node-shape, property-shape, concept, terminology and concept-collection. If the element corresponds to two things, e.g. both a class and a node-shape they can be listed both with a separating comma, the first should be considered dominant.
+><span id="svg2"></span> **Rule SVG-2:** An element corresponding to an INSPEC entity MUST have a custom data attribute on the form `data-inspec-type="TYPE"` where TYPE is one of foundational, application-profile, diagram, data-vocabulary, class, property, node-shape, property-shape, concept, terminology and concept-collection. If the element corresponds to two things, e.g. both a class and a node-shape they can be listed both with a separating comma, the first should be considered dominant.
 
-><a id="svg3"></a> **Rule SVG-3:** An element corresponding to an INSPEC entity MAY have an id on the form `id="d_EID"` where EID is the md5 sum[^note3] of the entity's URI.
+><span id="svg3"></span> **Rule SVG-3:** An element corresponding to an INSPEC entity MAY have an id on the form `id="d_EID"` where EID is the md5 sum<sup><a href="#fn3" id="fn3_1">[3]</a></sup> of the entity's URI.
 
-><a id="svg4"></a> **Rule SVG-4:** An element with type node-shape or property-shape MAY have a custom data attribute on the form `data-inspec-public="true"` if it is public according to rule AP-3 or AP-4.
+><span id="svg4"></span> **Rule SVG-4:** An element with type node-shape or property-shape MAY have a custom data attribute on the form `data-inspec-public="true"` if it is public according to rule AP-3 or AP-4.
 
-><a id="svg5"></a> **Rule SVG-5:** An element with type node-shape that is also public MAY have a custom data attribute on the form `data-inspec-weight="WEIGHT"` where WEIGHT is either "main" or "supportive" according to rule AP-5.
+><span id="svg5"></span> **Rule SVG-5:** An element with type node-shape that is also public MAY have a custom data attribute on the form `data-inspec-weight="WEIGHT"` where WEIGHT is either "main" or "supportive" according to rule AP-5.
 
-[^note1]: Both RDFS and SKOS introduce building blocks (classes and properties) for defining things (other classes, properties, concepts, collections) in an open world manner. However, both vocabularies and terminologies needs to work in the context of semantic specifications where it is stated explicitly what is included, hence it corresponds to a closed world perspective. Hence, in both RDFS-INSPEC and SKOS-INSPEC there is a restriction to assume that everything needed is provided in the indicated RDF Datasets.
-
-[^note2]: SHACL supports imports declared via `owl:import`, the rules are written from the perspective that these are respected and all RDF Datasets (potentially recursively) are imported first into a single RDF Dataset.
-
-[^note3]: The id value could in principle be the URI, however, it is highly likely that we want to write CSS rules targeting individual elements and then we need to be more restrictive as CSS rules cannot use URIs as part of selectors.
+<section id="footnotes" style="font-size:smaller;border-top:1px solid" class="informative">
+<ol>
+ <li id="fn1">Both RDFS and SKOS introduce building blocks (classes and properties) for defining things (other classes, properties, concepts, collections) in an open world manner. However, both vocabularies and terminologies needs to work in the context of semantic specifications where it is stated explicitly what is included, hence it corresponds to a closed world perspective. Hence, in both RDFS-INSPEC and SKOS-INSPEC there is a restriction to assume that everything needed is provided in the indicated RDF Datasets. <a href="#fn1_1">↩<sup>1</sup></a><a href="#fn1_2">↩<sup>2</sup></a></li>
+ <li id="fn2">SHACL supports imports declared via `owl:import`, the rules are written from the perspective that these are respected and all RDF Datasets (potentially recursively) are imported first into a single RDF Dataset. <a href="#fn2_1">↩</a></li>
+ <li id="fn3">The id value could in principle be the URI, however, it is highly likely that we want to write CSS rules targeting individual elements and then we need to be more restrictive as CSS rules cannot use URIs as part of selectors. <a href="#fn3_1">↩</a></li>
+</ol>
+</section>

--- a/docs/tweaks.js
+++ b/docs/tweaks.js
@@ -1,0 +1,9 @@
+window.onload = (event) => {
+  // Replace link to md files to rendered html equivalents
+  var mdLinks = document.querySelectorAll('a[href$=".md"]');
+  mdLinks.forEach(a =>{
+    var oldHref = a.getAttribute('href');
+    var newHref = oldHref.slice(0, oldHref.lastIndexOf(".")) + ".html"
+    a.setAttribute('href', newHref)
+  });
+};


### PR DESCRIPTION
# Pull Request Description

This sets up a Respec formatted version of rules.md deployed at docs/index.html

This requires minor formatting changes to rules.md:
* anchors moved from a-tags to span-tags
* cannot use markdown-footnotes

The config.js includes a few overrides to the default respec behaviour in order to
* remove W3C specific wording
* keeping all of the content in the config

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
