### PR TITLE
replace requires on the spec resource by dcat:subject on the spec part

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -39,6 +39,7 @@ ex:dv1 a prof:ResourceDescriptor ;
    dcterms:title "Data vocabulary for DocPub1.0";
    dcterms:conformsTo inspec:RDFS ;
    dcterms:format "text/turtle" ;
+   dcterms:subject ex:DV1Ontology ;
    prof:hasArtifact ex:DV1File ;
    prof:hasRole prof:schema, prof:vocabulary .
 
@@ -46,6 +47,7 @@ ex:dv2 a prof:ResourceDescriptor ;
    dcterms:title "Data vocabulary for Dublin Core";
    dcterms:conformsTo inspec:RDFS ;
    prof:isInheritedFrom ex:spec_DCTERMS ;
+   dcterms:subject dcterms: ;
    dcterms:format "rdf/xml" ;
    prof:hasArtifact <https://www.dublincore.org/specifications/dublin-core/dcmi-terms/dublin_core_terms.rdf> ;
    prof:hasRole prof:schema, prof:vocabulary .
@@ -54,6 +56,7 @@ ex:dv3 a prof:ResourceDescriptor ;
    dcterms:title "Data vocabulary for Friend of a Friend (FOAF)";
    dcterms:conformsTo inspec:RDFS ;
    prof:isInheritedFrom ex:spec_FOAF ;
+   dcterms:subject foaf: ;
    dcterms:format "rdf/xml" ;
    prof:hasArtifact <http://xmlns.com/foaf/spec/index.rdf> ;
    prof:hasRole prof:schema, prof:vocabulary .
@@ -61,6 +64,7 @@ ex:dv3 a prof:ResourceDescriptor ;
 ex:te1 a prof:ResourceDescriptor ;
    dcterms:title "Data themes terminology from EU publication office";
    dcterms:conformsTo inspec:SKOS ;
+   dcterms:subject dtheme: ;
    dcterms:format "text/turtle" ;
    prof:hasArtifact ex:TE1File ;
    prof:hasRole prof:vocabulary .

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -16,7 +16,7 @@ For a specification to be considered a interoperable specification the following
 
 ><span id="inspec1"></span> **Rule INSPEC-1:** The "interoperable specification resource" and its parts MUST have URIs and be described with PROF, the interoperable specification resource must be typed as `prof:Profile` or `dcterms:Standard` and have a `dcterms:conformsTo` point to `inspec:PROF`
 
-><span id="inspec2"></span> **Rule INSPEC-2:** An interoperable specification part MAY be a data vocabulary, a terminology, an application profile or a diagram. Other parts may exist but have no prescribed meaning by the interoperable specification profile.
+><span id="inspec2"></span> **Rule INSPEC-2:** All specification parts MUST be indicated via the `prof:hasResource` property from the interoperable specification and be typed as `prof:ResourceDescriptor`. An interoperable specification part MAY be a data vocabulary, a terminology, an application profile or a diagram. Other parts may exist but have no prescribed meaning by the interoperable specification profile.
 
 ><span id="inspec3"></span> **Rule INSPEC-3:** Each data vocabulary MUST be detected by `dcterms:conformsTo` pointing to `inspec:RDFS` and MUST be possible to interpret as RDFS-INSPEC.
 
@@ -48,7 +48,7 @@ RDFS-INSPEC builds on top of the RDF Schema specification by providing the follo
 
 ><span id="dv5"></span> **Rule DV-5:** Classes and properties from other vocabularies MAY BE included in the RDF Dataset, e.g. when being pointed to via `rdfs:subClassOf` and `rdfs:subProperty`, but MUST NOT point to the same "data vocabulary resource" via the `rdfs:isDefinedBy` property
 
-><span id="dv6"></span> **Rule DV-6:** The "data vocabulary resource" must be indicated via the `dcterms:requires` property from the "interoperable specification resource" (introduced in Rule INSPEC-1)
+><span id="dv6"></span> **Rule DV-6:** The "data vocabulary resource" MUST be indicated via the `dcterms:subject` property from the "interoperable specification part" (introduced in Rule INSPEC-2).
 
 ><span id="dv7"></span> **Rule DV-7:** The "data vocabulary resource" MAY be indicated via the `inspec:reuses` or `inspec:introduces` properties from the "interoperable specification resource" (introduced in Rule INSPEC-1)
 
@@ -64,7 +64,7 @@ SKOS-INSPEC builds on top of the SKOS specification by providing the following a
 
 ><span id="te4"></span> **Rule TE-4:** All concepts, collections as well as the terminology resource MUST have URIs
 
-><span id="te5"></span> **Rule TE-5:** The "terminology resource" must be indicated via the `dcterms:requires` property from the "interoperable specification resource" (introduced in Rule INSPEC-1)
+><span id="te5"></span> **Rule TE-5:** The "terminology resource" MUST be indicated via the `dcterms:subject` property from the "interoperable specification part" (introduced in Rule INSPEC-2).
 
 ><span id="te6"></span> **Rule TE-6:** The "terminology resource" MAY be indicated via the `inspec:reuses` or `inspec:introduces` properties from the "interoperable specification resource" (introduced in Rule INSPEC-1)
 


### PR DESCRIPTION
# Pull Request Description

This replaces `dcterms:requires` on the "interoperable specification resource" by `dcterms:subject` on the "interoperable specification part". This is done in part because AP-14 already uses `dcterms:requires` for classes, properties and terminologies but primarily so that the artefact of a specification part does not have to be unpacked in order to understand which resource it corresponds to.

Also clarifies that  the relationship between the specification and its parts should also be described using "prof".

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
