### PR TITLE
introduce inspec:reuses inspec:introduces

### DIFF
--- a/datavoc/vocabulary.rdf
+++ b/datavoc/vocabulary.rdf
@@ -70,4 +70,21 @@
     <rdfs:range rdf:resource="http://www.w3.org/ns/shacl#Shape"/>
     <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/dx/prof/isProfileOf"/>
   </rdf:Property>
+
+  <rdf:Property rdf:about="https://w3id.org/inspec/datavoc/reuses">
+    <rdfs:label xml:lang="en">reuses</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
+    <rdfs:comment xml:lang="en">A specification reuses a resource if it is needed by the specification but was originally introduced by a different specification</rdfs:comment>
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
+    <rdfs:domain rdf:resource="http://purl.org/dc/terms/Standard"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  </rdf:Property>
+  <rdf:Property rdf:about="https://w3id.org/inspec/datavoc/introduces">
+    <rdfs:label xml:lang="en">introduces</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
+    <rdfs:comment xml:lang="en">A specification introduces a resource if it is first introduced by a the same specification</rdfs:comment>
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
+    <rdfs:domain rdf:resource="http://purl.org/dc/terms/Standard"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Resource"/>
+  </rdf:Property>
 </rdf:RDF>

--- a/datavoc/vocabulary.ttl
+++ b/datavoc/vocabulary.ttl
@@ -20,13 +20,13 @@ inspec:PROF a rdfs:Class ;
 inspec:RDFS a rdfs:Class ;
   rdfs:label "RDFS"@en ;
   rdfs:isDefinedBy inspec: ;
-  rdfs:comment "This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-6."@en ;
+  rdfs:comment "This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-7."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/rdf12-schema/> .
 
 inspec:SKOS a rdfs:Class ;
   rdfs:label "SKOS"@en ;
   rdfs:isDefinedBy inspec: ;
-  rdfs:comment "This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-5."@en ;
+  rdfs:comment "This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-6."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/skos-reference/> .
 
 inspec:SHACL a rdfs:Class ;
@@ -61,3 +61,19 @@ inspec:refines a rdf:Property ;
   rdfs:domain sh:Shape ;
   rdfs:range sh:Shape ;
   rdfs:seeAlso prof:isProfileOf .
+
+inspec:reuses a rdf:Property ;
+  rdfs:label "reuses"@en ;
+  rdfs:isDefinedBy inspec: ;
+  rdfs:comment "A specification reuses a resource if it is needed by the specification but was originally introduced by a different specification"@en ;
+  rdfs:subPropertyOf dcterms:relation ;
+  rdfs:domain dcterms:Standard ;
+  rdfs:range rdfs:Resource .
+
+inspec:introduces a rdf:Property ;
+  rdfs:label "introduces"@en ;
+  rdfs:isDefinedBy inspec: ;
+  rdfs:comment "A specification introduces a resource if it is first introduced by a the same specification"@en ;
+  rdfs:subPropertyOf dcterms:relation ;
+  rdfs:domain dcterms:Standard ;
+  rdfs:range rdfs:Resource .

--- a/docs/bootstrapping.md
+++ b/docs/bootstrapping.md
@@ -14,11 +14,11 @@ This is a specification corresponding to a profile of PROF used to capture an in
 
 ## inspec:RDFS
 
-This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-6.
+This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-7.
 
 ## inspec:SKOS
 
-This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-5.
+This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-6.
 
 ## inspec:SHACL
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -77,9 +77,7 @@ ex:vi1 a prof:ResourceDescriptor ;
 The following triples can be provided as part of PROF-INSPEC, alternatively they can be auto generated as part of the harvesting process.
 
 ```turtle
-ex:spec1 dcterms:requires ex:DV1Ontology ;
-   dcterms:requires dtheme: ;
-   dcterms:hasPart ex:ns-document ;
+ex:spec1 dcterms:hasPart ex:ns-document ;
    dcterms:hasPart ex:ns-title ;
    dcterms:hasPart ex:ns-created ;
    dcterms:hasPart ex:ns-publisher ;
@@ -87,16 +85,22 @@ ex:spec1 dcterms:requires ex:DV1Ontology ;
    dcterms:hasPart ex:ns-person ;
    dcterms:hasPart ex:ns-name ;
    dcterms:hasPart ex:ns-mbox ;
-   dcterms:hasPart ex:ns-pnr ;
-   dcterms:requires foaf:Document ;
-   dcterms:requires dcterms:title ;
-   dcterms:requires dcterms:created ;
-   dcterms:requires dcterms:publisher ;
-   dcterms:requires dcterms:subject ;
-   dcterms:requires foaf:Person ;
-   dcterms:requires foaf:name ;
-   dcterms:requires foaf:mbox ;
-   dcterms:requires ex:personNumber .
+   dcterms:hasPart ex:ns-pnr;
+   inspec:reuses foaf:Document ;
+   inspec:reuses dcterms:title ;
+   inspec:reuses dcterms:created ;
+   inspec:reuses dcterms:publisher ;
+   inspec:reuses dcterms:subject ;
+   inspec:reuses foaf:Person ;
+   inspec:reuses foaf:name ;
+   inspec:reuses foaf:mbox ;
+   inspec:introduces ex:personNumber ;
+   inspec:reuses dtheme: .
+
+# --- optional ---
+ex:spec1 inspec:introduces ex:DV1Ontology ;
+   inspec:reuses dcterms: ;
+   inspec:reuses foaf: .
 ```
 
 ## RDFS-INSPEC expression

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -32,7 +32,7 @@ For a specification to be considered a interoperable specification the following
 
 ><span id="inspec9"></span> **Rule INSPEC-9:** A profile interoperable specification MUST list all data vocabularies and terminologies it **uses** in the application profile explicitly as interoperable specification parts
 
-><span id="inspec10"></span> **Rule INSPEC-10:** Data vocabularies and terminologies that are **reused** SHOULD indicate that by referring to the interoperable specification where they where introduced via the `prof:isInheritedFrom` property
+><span id="inspec10"></span> **Rule INSPEC-10:** Interoperable specification parts that are **reused** (as opposed to **introduced**) SHOULD indicate that by referring to the interoperable specification where they where introduced via the `prof:isInheritedFrom` property
 
 ## Rules for data vocabularies - RDFS-INSPEC
 
@@ -50,6 +50,8 @@ RDFS-INSPEC builds on top of the RDF Schema specification by providing the follo
 
 ><span id="dv6"></span> **Rule DV-6:** The "data vocabulary resource" must be indicated via the `dcterms:requires` property from the "interoperable specification resource" (introduced in Rule INSPEC-1)
 
+><span id="dv7"></span> **Rule DV-7:** The "data vocabulary resource" MAY be indicated via the `inspec:reuses` or `inspec:introduces` properties from the "interoperable specification resource" (introduced in Rule INSPEC-1)
+
 ## Rules for terminologies - SKOS-INSPEC
 
 SKOS-INSPEC builds on top of the SKOS specification by providing the following additional restrictions:
@@ -63,6 +65,8 @@ SKOS-INSPEC builds on top of the SKOS specification by providing the following a
 ><span id="te4"></span> **Rule TE-4:** All concepts, collections as well as the terminology resource MUST have URIs
 
 ><span id="te5"></span> **Rule TE-5:** The "terminology resource" must be indicated via the `dcterms:requires` property from the "interoperable specification resource" (introduced in Rule INSPEC-1)
+
+><span id="te6"></span> **Rule TE-6:** The "terminology resource" MAY be indicated via the `inspec:reuses` or `inspec:introduces` properties from the "interoperable specification resource" (introduced in Rule INSPEC-1)
 
 ## Rules for application profiles - SHACL-INSPEC
 
@@ -94,7 +98,7 @@ SHACL-INSPEC builds on top of the SHACL specification by providing additional re
 
 ><span id="ap13"></span> **Rule AP-13:** Shapes used for refinement or for variants MAY reside in other RDF Datasets as long as the dataset is pointed to via `owl:imports` AND there is either a `prof:isProfileOf` or a `inspec:variant` relation between the application profile resources.
 
-><span id="ap14"></span> **Rule AP-14:** All classes, properties and terminologies referred to via shapes should be explicitly indicated via the `dcterms:requires` property from the "interoperable specification resource" (introduced in Rule INSPEC-1)
+><span id="ap14"></span> **Rule AP-14:** All classes, properties and terminologies referred to via shapes should be explicitly indicated via the `inspec:reuses` or `inspec:introduces` properties from the "interoperable specification resource" (introduced in Rule INSPEC-1)
 
 ## Rules for diagrams - SVG-INSPEC
 


### PR DESCRIPTION
# Pull Request Description

This introduces `inspec:reuses` and `inspec:introduces` as a replacement of `dcterms:requires` to make a clearer distinction between the resources being introduced in the specification and those being reused. 

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
