### PR TITLE
make inspec:RDFS etc. instances of dcterms:Standard

### DIFF
--- a/datavoc/vocabulary.rdf
+++ b/datavoc/vocabulary.rdf
@@ -3,42 +3,42 @@
   xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
   xmlns:owl="http://www.w3.org/2002/07/owl#"
+  xmlns:dcterms="http://purl.org/dc/terms/"
 >
-  <rdfs:Class rdf:about="https://w3id.org/inspec/datavoc/PROF">
+  <owl:Ontology rdf:about="https://w3id.org/inspec/datavoc/">
+    <rdfs:label xml:lang="en">The Interoperable Specifications Profile (INSPEC) Vocabulary</rdfs:label>
+    <rdfs:comment xml:lang="en">This vocabulary defines terms used in INSPEC.</rdfs:comment>
+  </owl:Ontology>
+  <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/PROF">
     <rdfs:label xml:lang="en">PROF</rdfs:label>
-    <rdfs:isDefinedBy>
-      <owl:Ontology rdf:about="https://w3id.org/inspec/datavoc/">
-        <rdfs:label xml:lang="en">The Interoperable Specifications Profile (INSPEC) Vocabulary</rdfs:label>
-        <rdfs:comment xml:lang="en">This vocabulary defines terms used in INSPEC.</rdfs:comment>
-      </owl:Ontology>
-    </rdfs:isDefinedBy>
+    <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules INSPEC-1 — INSPEC-10.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/dx-prof/"/>
-  </rdfs:Class>
-  <rdfs:Class rdf:about="https://w3id.org/inspec/datavoc/RDFS">
+  </dcterms:Standard>
+  <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/RDFS">
     <rdfs:label xml:lang="en">RDFS</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-6.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/rdf12-schema/"/>
-  </rdfs:Class>
-  <rdfs:Class rdf:about="https://w3id.org/inspec/datavoc/SKOS">
+  </dcterms:Standard>
+  <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/SKOS">
     <rdfs:label xml:lang="en">SKOS</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-5.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/skos-reference/"/>
-  </rdfs:Class>
-  <rdfs:Class rdf:about="https://w3id.org/inspec/datavoc/SHACL">
+  </dcterms:Standard>
+  <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/SHACL">
     <rdfs:label xml:lang="en">SHACL</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the rules AP-1 — AP-14.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/shacl"/>
-  </rdfs:Class>
-  <rdfs:Class rdf:about="https://w3id.org/inspec/datavoc/SVG">
+  </dcterms:Standard>
+  <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/SVG">
     <rdfs:label xml:lang="en">SVG</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SVG used to capture an expression of diagrams for interoperable specifications. Corresponds to the rules SVG-1 — SVG-5.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/SVG11/"/>
-  </rdfs:Class>
+  </dcterms:Standard>
   <rdf:Property rdf:about="https://w3id.org/inspec/datavoc/variant">
     <rdfs:label xml:lang="en">variant</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
@@ -70,7 +70,6 @@
     <rdfs:range rdf:resource="http://www.w3.org/ns/shacl#Shape"/>
     <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/dx/prof/isProfileOf"/>
   </rdf:Property>
-
   <rdf:Property rdf:about="https://w3id.org/inspec/datavoc/reuses">
     <rdfs:label xml:lang="en">reuses</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>

--- a/datavoc/vocabulary.ttl
+++ b/datavoc/vocabulary.ttl
@@ -11,31 +11,31 @@ inspec: a owl:Ontology ;
   rdfs:label "The Interoperable Specifications Profile (INSPEC) Vocabulary"@en ;
   rdfs:comment "This vocabulary defines terms used in INSPEC."@en .
 
-inspec:PROF a rdfs:Class ;
+inspec:PROF a dct:Standard ;
   rdfs:label "PROF"@en ;
   rdfs:isDefinedBy inspec: ;
   rdfs:comment "This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules INSPEC-1 — INSPEC-10."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/dx-prof/> .
 
-inspec:RDFS a rdfs:Class ;
+inspec:RDFS a dct:Standard ;
   rdfs:label "RDFS"@en ;
   rdfs:isDefinedBy inspec: ;
   rdfs:comment "This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-7."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/rdf12-schema/> .
 
-inspec:SKOS a rdfs:Class ;
+inspec:SKOS a dct:Standard ;
   rdfs:label "SKOS"@en ;
   rdfs:isDefinedBy inspec: ;
   rdfs:comment "This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-6."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/skos-reference/> .
 
-inspec:SHACL a rdfs:Class ;
+inspec:SHACL a dct:Standard ;
   rdfs:label "SHACL"@en ;
   rdfs:isDefinedBy inspec: ;
   rdfs:comment "This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the rules AP-1 — AP-14."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/shacl> .
 
-inspec:SVG a rdfs:Class ;
+inspec:SVG a dct:Standard ;
   rdfs:label "SVG"@en ;
   rdfs:isDefinedBy inspec: ;
   rdfs:comment "This is a specification corresponding to a profile of SVG used to capture an expression of diagrams for interoperable specifications. Corresponds to the rules SVG-1 — SVG-5."@en ;


### PR DESCRIPTION
# Pull Request Description

This makes `inspec:RDFS` etc. instances of `dcterms:Standard` which is needed in order to respect the range of `dcterms:conformsTo`.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
