### PR TITLE
drop DV-7 and TE-6, remove terminologies from AP-14

### DIFF
--- a/datavoc/vocabulary.ttl
+++ b/datavoc/vocabulary.ttl
@@ -20,13 +20,13 @@ inspec:PROF a dct:Standard ;
 inspec:RDFS a dct:Standard ;
   rdfs:label "RDFS"@en ;
   rdfs:isDefinedBy inspec: ;
-  rdfs:comment "This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-7."@en ;
+  rdfs:comment "This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-6."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/rdf12-schema/> .
 
 inspec:SKOS a dct:Standard ;
   rdfs:label "SKOS"@en ;
   rdfs:isDefinedBy inspec: ;
-  rdfs:comment "This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-6."@en ;
+  rdfs:comment "This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-5."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/skos-reference/> .
 
 inspec:SHACL a dct:Standard ;

--- a/docs/ap.md
+++ b/docs/ap.md
@@ -37,7 +37,7 @@ The following information MUST be provided for an application profile resource:
 * A label expressed via the property `sh:name`
 * A list of public node shapes indicated via the property `dcterms:hasPart`
 * A list of public property shapes indicated via the property `dcterms:hasPart`
-* A list of all classes and properties used in the application profile must be indicated via the property `dcterms:requires` (the foundational classes from SKOS and RDFS should be excluded)
+* A list of all classes and properties used in the application profile must be indicated via the properties `inspec:reuses` or `inspec:introduces` (the foundational classes from SKOS and RDFS should be excluded)
 
 The following information MAY be provided:
 

--- a/docs/bootstrapping.md
+++ b/docs/bootstrapping.md
@@ -2,7 +2,7 @@
 
 To make interoperable specifications work we need a clear way to identify the different parts. This is achieved by indicating the character of various resources by saying that they conform to a specification. Note that these bootstrapping specifications need not be interoperable specifications in themselves (but it does not hurt if they are).
 
-The bootstrapping specifications have not yet received a stable namespace, but a good candidate may be:
+The bootstrapping specifications use the following namespace:
 
 namespace | expansion
 --- | ---
@@ -14,11 +14,11 @@ This is a specification corresponding to a profile of PROF used to capture an in
 
 ## inspec:RDFS
 
-This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-7.
+This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-6.
 
 ## inspec:SKOS
 
-This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-6.
+This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-5.
 
 ## inspec:SHACL
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -80,10 +80,16 @@ ex:vi1 a prof:ResourceDescriptor ;
 The following triples can be provided as part of PROF-INSPEC, alternatively they can be auto generated as part of the harvesting process.
 
 ```turtle
-# optional, can also be calculated at harvest
-ex:spec1 inspec:introduces ex:DV1Ontology ;
-  inspec:reuses dcterms: ;
-  inspec:reuses foaf: .
+# referenced classes and properties - AP-14
+ex:spec1 inspec:reuses foaf:Document ;
+  inspec:reuses dcterms:title ;
+  inspec:reuses dcterms:created ;
+  inspec:reuses dcterms:publisher ;
+  inspec:reuses dcterms:subject ;
+  inspec:reuses foaf:Person ;
+  inspec:reuses foaf:name ;
+  inspec:reuses foaf:mbox ;
+  inspec:introduces ex:personNumber .
 
 # reproduced from SHACL-INSPEC for added discoverability
 ex:spec1 dcterms:hasPart ex:ns-document ;
@@ -94,17 +100,7 @@ ex:spec1 dcterms:hasPart ex:ns-document ;
   dcterms:hasPart ex:ns-person ;
   dcterms:hasPart ex:ns-name ;
   dcterms:hasPart ex:ns-mbox ;
-  dcterms:hasPart ex:ns-pnr;
-  inspec:reuses foaf:Document ;
-  inspec:reuses dcterms:title ;
-  inspec:reuses dcterms:created ;
-  inspec:reuses dcterms:publisher ;
-  inspec:reuses dcterms:subject ;
-  inspec:reuses foaf:Person ;
-  inspec:reuses foaf:name ;
-  inspec:reuses foaf:mbox ;
-  inspec:introduces ex:personNumber ;
-  inspec:reuses dtheme: .
+  dcterms:hasPart ex:ns-pnr .
 ```
 
 ## RDFS-INSPEC expression
@@ -131,7 +127,7 @@ The following is just regular SKOS.
 ```turtle
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix dtheme: <http://publications.europa.eu/resource/authority/data-theme/>
+@prefix dtheme: <http://publications.europa.eu/resource/authority/data-theme/> .
 
 dtheme:ECON a skos:Concept ;
   skos:prefLabel "Economy"@en ;
@@ -198,10 +194,10 @@ ex:ps-subject a sh:PropertyShape ;
     sh:severity sh:Info ;
     sh:property [
       sh:path rdf:type ;
-      sh:hasValue skos:Concept
+      sh:hasValue skos:Concept ;
     ], [
       sh:path skos:inScheme ;
-      sh:hasValue dtheme:
+      sh:hasValue dtheme: ;
     ]
   ] .
 
@@ -250,16 +246,4 @@ ex:spec1 dcterms:hasPart ex:ns-document ;
   dcterms:hasPart ex:ns-name ;
   dcterms:hasPart ex:ns-mbox ;
   dcterms:hasPart ex:ns-pnr .
-
-# referenced classes, properties and terminologies - AP-14
-ex:spec1 inspec:reuses foaf:Document ;
-  inspec:reuses dcterms:title ;
-  inspec:reuses dcterms:created ;
-  inspec:reuses dcterms:publisher ;
-  inspec:reuses dcterms:subject ;
-  inspec:reuses foaf:Person ;
-  inspec:reuses foaf:name ;
-  inspec:reuses foaf:mbox ;
-  inspec:introduces ex:personNumber ;
-  inspec:reuses dtheme: .
 ```

--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -8,19 +8,19 @@ Below we will refer to the interoperable specification resource as INSPEC resour
 
 ### Data vocabulary
 
-If the data data vocabulary is reused, i.e. `prof:isInheritedFrom` is provided, no loading is done. If the referenced foundational or interoperable specification does not exist already in the system a warning is logged.
+If the data vocabulary is reused, i.e. `prof:isInheritedFrom` is provided, no loading is done. If the referenced foundational or interoperable specification does not exist already in the system a warning is logged.
 
-If the data vocabulary is not reused it is attempted to be retrieved from either the `prof:hasArtifact` value or the subject. The retrieved RDF datasource is checked against RDFS-INSPEC before being loaded into the triplestore. All classes and properties should be available in the triplestore. The ontology resource should also be available for easy access in the triplestore and also pointed to via `dct:requires` from the INSPEC resource. (The classes and properties will only be pointed to via `dct:requires` if they are explicitly used as indicated in the application profile, see below.)
+If the data vocabulary is not reused it is attempted to be retrieved from either the `prof:hasArtifact` value or the subject. The retrieved RDF datasource is checked against RDFS-INSPEC before being loaded into the triplestore. All classes and properties should be available in the triplestore. The ontology resource should also be available for easy access in the triplestore and also pointed to via `dcterms:subject` from the corresponding ResourceDescriptor. (The classes and properties will only be pointed to via the `inspec:reuses` or `inspec:introduces` properties from the INSPEC resource if they are explicitly used as indicated in the application profile, see below.)
 
 ### Terminology
 
 If the terminology is reused, i.e. `prof:isInheritedFrom` is provided, no loading is done. If the referenced foundational or interoperable specification does not exist already in the system a warning is logged.
 
-If the terminology is not reused it is attempted to be retrieved from either the `prof:hasArtifact` value or the subject. The retrieved RDF datasource is checked against SKOS-INSPEC before being loaded into the triplestore. All concepts, concept schemes and collections should be available in the triplestore for easy access. The terminology should be pointed to via `dct:requires` from the INSPEC resource.
+If the terminology is not reused it is attempted to be retrieved from either the `prof:hasArtifact` value or the subject. The retrieved RDF datasource is checked against SKOS-INSPEC before being loaded into the triplestore. All concepts, concept schemes and collections should be available in the triplestore for easy access. The terminology should be pointed to via `dcterms:subject` from the corresponding ResourceDescriptor.
 
 ### Application profile
 
-The application is attempted to be retrieved from either the `prof:hasArtifact` value or the subject. The retrieved RDF datasource is checked against SHACL-INSPEC before proceeding. All public property and node shapes introduced in this application profile should be indicated via the `dct:hasPart` from the INSPEC resource. Further metadata about the node and property shapes needs not be added to the triplestore directly. Only the metadata about the INSPEC resource itself from the application profile needs to be added. All classes and properties referenced from node and property shapes should be indicated via the `dct:requires` property from the INSPEC resource.
+The application is attempted to be retrieved from either the `prof:hasArtifact` value or the subject. The retrieved RDF datasource is checked against SHACL-INSPEC before proceeding. All public property and node shapes introduced in this application profile should be indicated via the `dcterms:hasPart` from the INSPEC resource. Further metadata about the node and property shapes needs not be added to the triplestore directly. Only the metadata about the INSPEC resource itself from the application profile needs to be added. All classes and properties referenced from node and property shapes should be indicated via the `inspec:reuses` or `inspec:introduces` properties from the INSPEC resource.
 
 ### Diagram
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -14,7 +14,7 @@ The rules for interoperable specifications are divided into five parts:
 
 For a specification to be considered a interoperable specification the following must apply:
 
-><span id="inspec1"></span> **Rule INSPEC-1:** The "interoperable specification resource" and its parts MUST have URIs and be described with PROF, the interoperable specification resource must be typed as `prof:Profile` or `dcterms:Standard` and have a `dcterms:conformsTo` point to `inspec:PROF`
+><span id="inspec1"></span> **Rule INSPEC-1:** The "interoperable specification resource" and its parts MUST have URIs and be described with PROF, the interoperable specification resource MUST be typed as `prof:Profile` or `dcterms:Standard` and have a `dcterms:conformsTo` point to `inspec:PROF`
 
 ><span id="inspec2"></span> **Rule INSPEC-2:** All specification parts MUST be indicated via the `prof:hasResource` property from the interoperable specification and be typed as `prof:ResourceDescriptor`. An interoperable specification part MAY be a data vocabulary, a terminology, an application profile or a diagram. Other parts may exist but have no prescribed meaning by the interoperable specification profile.
 
@@ -50,8 +50,6 @@ RDFS-INSPEC builds on top of the RDF Schema specification by providing the follo
 
 ><span id="dv6"></span> **Rule DV-6:** The "data vocabulary resource" MUST be indicated via the `dcterms:subject` property from the "interoperable specification part" (introduced in Rule INSPEC-2).
 
-><span id="dv7"></span> **Rule DV-7:** The "data vocabulary resource" MAY be indicated via the `inspec:reuses` or `inspec:introduces` properties from the "interoperable specification resource" (introduced in Rule INSPEC-1)
-
 ## Rules for terminologies - SKOS-INSPEC
 
 SKOS-INSPEC builds on top of the SKOS specification by providing the following additional restrictions:
@@ -66,15 +64,13 @@ SKOS-INSPEC builds on top of the SKOS specification by providing the following a
 
 ><span id="te5"></span> **Rule TE-5:** The "terminology resource" MUST be indicated via the `dcterms:subject` property from the "interoperable specification part" (introduced in Rule INSPEC-2).
 
-><span id="te6"></span> **Rule TE-6:** The "terminology resource" MAY be indicated via the `inspec:reuses` or `inspec:introduces` properties from the "interoperable specification resource" (introduced in Rule INSPEC-1)
-
 ## Rules for application profiles - SHACL-INSPEC
 
 SHACL-INSPEC builds on top of the SHACL specification by providing additional restrictions. Since SHACL is a rich language the following rules does not cover all situations. For instance, the following rules does not indicate how to specify how to restrict to concepts from a specific terminology. For a more complete treatment see the [SHACL-INSPEC separate document](ap.md) for patterns on how to use the profile in various situations.
 
 ><span id="ap1"></span> **Rule AP-1:** An application profile MUST be expressed in a single RDF Dataset<sup><a href="#fn2" id="fn2_1">[2]</a></sup>
 
-><span id="ap2"></span> **Rule AP-2:** There MUST be a single "application profile resource" with a URI in the RDF Dataset AND it must be the same as the "interoperable specification resource" (introduced in Rule INSPEC-1)
+><span id="ap2"></span> **Rule AP-2:** There MUST be a single "application profile resource" with a URI in the RDF Dataset AND it MUST be the same as the "interoperable specification resource" (introduced in Rule INSPEC-1)
 
 ><span id="ap3"></span> **Rule AP-3:** All property shapes with a severity of `sh:VIOLATION` and with at least one constraint (`sh:and` for specialization does not count) are considered **public** and they MUST have URIs and MUST also be pointed to from the application profile resource via the `dcterms:hasPart` property
 
@@ -98,7 +94,7 @@ SHACL-INSPEC builds on top of the SHACL specification by providing additional re
 
 ><span id="ap13"></span> **Rule AP-13:** Shapes used for refinement or for variants MAY reside in other RDF Datasets as long as the dataset is pointed to via `owl:imports` AND there is either a `prof:isProfileOf` or a `inspec:variant` relation between the application profile resources.
 
-><span id="ap14"></span> **Rule AP-14:** All classes, properties and terminologies referred to via shapes should be explicitly indicated via the `inspec:reuses` or `inspec:introduces` properties from the "interoperable specification resource" (introduced in Rule INSPEC-1)
+><span id="ap14"></span> **Rule AP-14:** All classes and properties referred to via shapes SHOULD be explicitly indicated from the "interoperable specification resource" (introduced in Rule INSPEC-1). The indication should use `inspec:reuses` if the referred resource is part of a **reused** specification part (see Rule INSPEC-10), otherwise `inspec:introduces` should be used.
 
 ## Rules for diagrams - SVG-INSPEC
 


### PR DESCRIPTION
# Pull Request Description

Limit the use of `inspec:reuses`/`inspec:introduces` to only
classes and properties as data vocabularies and terminologies
can be inferred from `prof:isInheritedFrom` and `dcterms:subject`.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
