### PR TITLE
use inspec:refines also between application profile resources

### DIFF
--- a/datavoc/vocabulary.rdf
+++ b/datavoc/vocabulary.rdf
@@ -44,32 +44,23 @@
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">A shape or profile is a variant of another if it relaxes some of its constraints</rdfs:comment>
     <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
-    <rdfs:domain>
-      <rdf:Description rdf:nodeID="naf255206f4f948d1bb5e5f5f0440d55db1">
-        <owl:unionOf rdf:parseType="Collection">
-          <rdf:Description rdf:about="http://www.w3.org/ns/shacl#Shape"/>
-          <rdf:Description rdf:about="http://www.w3.org/ns/dx/prof/Profile"/>
-        </owl:unionOf>
-      </rdf:Description>
-    </rdfs:domain>
-    <rdfs:range>
-      <rdf:Description rdf:nodeID="naf255206f4f948d1bb5e5f5f0440d55db4">
-        <owl:unionOf rdf:parseType="Collection">
-          <rdf:Description rdf:about="http://www.w3.org/ns/shacl#Shape"/>
-          <rdf:Description rdf:about="http://www.w3.org/ns/dx/prof/Profile"/>
-        </owl:unionOf>
-      </rdf:Description>
-    </rdfs:range>
+    <rdfs:domain rdf:nodeID="ShapeOrProfile"/>
+    <rdfs:range rdf:nodeID="ShapeOrProfile"/>
   </rdf:Property>
   <rdf:Property rdf:about="https://w3id.org/inspec/datavoc/refines">
     <rdfs:label xml:lang="en">refines</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
     <rdfs:comment xml:lang="en">A shape refines another by adding additional constraints to it</rdfs:comment>
     <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
-    <rdfs:domain rdf:resource="http://www.w3.org/ns/shacl#Shape"/>
-    <rdfs:range rdf:resource="http://www.w3.org/ns/shacl#Shape"/>
-    <rdfs:seeAlso rdf:resource="http://www.w3.org/ns/dx/prof/isProfileOf"/>
+    <rdfs:domain rdf:nodeID="ShapeOrProfile"/>
+    <rdfs:range rdf:nodeID="ShapeOrProfile"/>
   </rdf:Property>
+  <rdf:Description rdf:nodeID="ShapeOrProfile">
+    <owl:unionOf rdf:parseType="Collection">
+      <rdf:Description rdf:about="http://www.w3.org/ns/shacl#Shape"/>
+      <rdf:Description rdf:about="http://www.w3.org/ns/dx/prof/Profile"/>
+    </owl:unionOf>
+  </rdf:Description>
   <rdf:Property rdf:about="https://w3id.org/inspec/datavoc/reuses">
     <rdfs:label xml:lang="en">reuses</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>

--- a/datavoc/vocabulary.ttl
+++ b/datavoc/vocabulary.ttl
@@ -58,9 +58,12 @@ inspec:refines a rdf:Property ;
   rdfs:isDefinedBy inspec: ;
   rdfs:comment "A shape refines another by adding additional constraints to it"@en ;
   rdfs:subPropertyOf dcterms:relation ;
-  rdfs:domain sh:Shape ;
-  rdfs:range sh:Shape ;
-  rdfs:seeAlso prof:isProfileOf .
+  rdfs:domain [
+	  owl:unionOf (sh:Shape prof:Profile)
+    ] ;
+  rdfs:range [
+	  owl:unionOf (sh:Shape prof:Profile)
+    ].
 
 inspec:reuses a rdf:Property ;
   rdfs:label "reuses"@en ;

--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -20,7 +20,7 @@ If the terminology is not reused it is attempted to be retrieved from either the
 
 ### Application profile
 
-The application is attempted to be retrieved from either the `prof:hasArtifact` value or the subject. The retrieved RDF datasource is checked against SHACL-INSPEC before proceeding. All public property and node shapes introduced in this application profile should be calculated and indicated via `dcterms:hasPart` from the INSPEC resource. Further metadata about the node and property shapes needs not be added to the triplestore directly. Only the metadata about the INSPEC resource itself from the application profile needs to be added. All classes and properties referenced from node and property shapes should be indicated via the `inspec:reuses` or `inspec:introduces` properties from the INSPEC resource.
+The application is attempted to be retrieved from either the `prof:hasArtifact` value or the subject. The retrieved RDF datasource is checked against SHACL-INSPEC before proceeding. All public property and node shapes introduced in this application profile should be calculated and indicated via `dcterms:hasPart` from the INSPEC resource. Further metadata about the node and property shapes needs not be added to the triplestore directly. Only the metadata about the INSPEC resource itself from the application profile needs to be added. All classes and properties referenced from node and property shapes should be indicated via the `inspec:reuses` or `inspec:introduces` properties from the INSPEC resource. If there is a second application profile referenced via an `inspec:refines` relationship, then this should also be added as a `prof:isProfileOf` relation from the INSPEC resource.
 
 ### Diagram
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -88,13 +88,13 @@ SHACL-INSPEC builds on top of the SHACL specification by providing additional re
 
 ><span id="ap10"></span> **Rule AP-10:** A node shape *B* MAY express that it is a **variant** of a public node shape *A* via the `inspec:variant` property only if for every property shape *X* in *A* either *X* or *Y* is in *B* where *Y* is a refinement or a variant of *X*. At least one of the property shapes must be a variant and not a refinement.
 
-><span id="ap11"></span> **Rule AP-11:** An application profile *B* MAY express that it is a **subprofile of** of an application profile *A* via the `prof:isProfileOf` property only if for every node shape *X* in *A* there is a refined node shape *Y* in *B*.
+><span id="ap11"></span> **Rule AP-11:** An application profile *B* MAY express that it is a **subprofile of** of an application profile *A* via the `inspec:refines` property only if for every node shape *X* in *A* there is a refined node shape *Y* in *B*.
 
 ><span id="ap12"></span> **Rule AP-12:** An application profile *B* MAY express that it is a **variant** of a application profile *A* via the `inspec:variant` property only if for every node shape *X* in *A* there is a variant or refined node shape *Y* in *B*, at least one of the node shapes must be a variant and not a refinement.
 
 ><span id="ap13"></span> **Rule AP-13:** All shapes of the application profile MUST point to the "application profile resource" via the `rdfs:isDefinedBy` property
 
-><span id="ap14"></span> **Rule AP-14:** Shapes used for refinement or for variants MAY reside in other RDF Datasets as long as the dataset is pointed to via `owl:imports` AND there is either a `prof:isProfileOf` or a `inspec:variant` relation between the application profile resources.
+><span id="ap14"></span> **Rule AP-14:** Shapes used for refinement or for variants MAY reside in other RDF Datasets as long as the dataset is pointed to via `owl:imports` AND there is either a `inspec:refines` or a `inspec:variant` relation between the application profile resources.
 
 ><span id="ap15"></span> **Rule AP-15:** Shapes from other application profiles used for refinement or for variants MAY be included in the RDF Dataset but MUST NOT point to the same "application profile resource" via the `rdfs:isDefinedBy` property
 


### PR DESCRIPTION
# Pull Request Description

This replaces the previous recommendation (using `prof:isProfileOf``) and also extends the range and domain of `inspec:refines` as a result.

`prof:isProfileOf` is therefore left unchanged from the Profiles vocabulary and can be used to also indicate other types of relationships. In particular between a `prof:Profile` and `dcterms:Standard`, which `inspec:refines` does not support.

For harvesting: `inspec:refines` will already be replicated on the PROF level, a derived `prof:isProfileOf` relation will now additionally be added.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
