### PR TITLE
Separate out enrichment rules

### DIFF
--- a/datavoc/vocabulary.rdf
+++ b/datavoc/vocabulary.rdf
@@ -12,7 +12,7 @@
   <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/PROF">
     <rdfs:label xml:lang="en">PROF</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
-    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules INSPEC-1 — INSPEC-10.</rdfs:comment>
+    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules PROF-1 — PROF-10.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/dx-prof/"/>
   </dcterms:Standard>
   <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/RDFS">

--- a/datavoc/vocabulary.rdf
+++ b/datavoc/vocabulary.rdf
@@ -12,31 +12,31 @@
   <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/PROF">
     <rdfs:label xml:lang="en">PROF</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
-    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules PROF-1 — PROF-10.</rdfs:comment>
+    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the PROF rules.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/dx-prof/"/>
   </dcterms:Standard>
   <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/RDFS">
     <rdfs:label xml:lang="en">RDFS</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
-    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-6.</rdfs:comment>
+    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the DV rules.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/rdf12-schema/"/>
   </dcterms:Standard>
   <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/SKOS">
     <rdfs:label xml:lang="en">SKOS</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
-    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-5.</rdfs:comment>
+    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the TE rules.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/skos-reference/"/>
   </dcterms:Standard>
   <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/SHACL">
     <rdfs:label xml:lang="en">SHACL</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
-    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the rules AP-1 — AP-16.</rdfs:comment>
+    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the AP rules.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/shacl"/>
   </dcterms:Standard>
   <dcterms:Standard rdf:about="https://w3id.org/inspec/datavoc/SVG">
     <rdfs:label xml:lang="en">SVG</rdfs:label>
     <rdfs:isDefinedBy rdf:resource="https://w3id.org/inspec/datavoc/"/>
-    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SVG used to capture an expression of diagrams for interoperable specifications. Corresponds to the rules SVG-1 — SVG-5.</rdfs:comment>
+    <rdfs:comment xml:lang="en">This is a specification corresponding to a profile of SVG used to capture an expression of diagrams for interoperable specifications. Corresponds to the SVG rules.</rdfs:comment>
     <rdfs:seeAlso rdf:resource="https://www.w3.org/TR/SVG11/"/>
   </dcterms:Standard>
   <rdf:Property rdf:about="https://w3id.org/inspec/datavoc/variant">

--- a/datavoc/vocabulary.ttl
+++ b/datavoc/vocabulary.ttl
@@ -14,7 +14,7 @@ inspec: a owl:Ontology ;
 inspec:PROF a dct:Standard ;
   rdfs:label "PROF"@en ;
   rdfs:isDefinedBy inspec: ;
-  rdfs:comment "This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules INSPEC-1 — INSPEC-10."@en ;
+  rdfs:comment "This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules PROF-1 — PROF-10."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/dx-prof/> .
 
 inspec:RDFS a dct:Standard ;

--- a/datavoc/vocabulary.ttl
+++ b/datavoc/vocabulary.ttl
@@ -14,31 +14,31 @@ inspec: a owl:Ontology ;
 inspec:PROF a dct:Standard ;
   rdfs:label "PROF"@en ;
   rdfs:isDefinedBy inspec: ;
-  rdfs:comment "This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules PROF-1 — PROF-10."@en ;
+  rdfs:comment "This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the PROF rules."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/dx-prof/> .
 
 inspec:RDFS a dct:Standard ;
   rdfs:label "RDFS"@en ;
   rdfs:isDefinedBy inspec: ;
-  rdfs:comment "This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-6."@en ;
+  rdfs:comment "This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the DV rules."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/rdf12-schema/> .
 
 inspec:SKOS a dct:Standard ;
   rdfs:label "SKOS"@en ;
   rdfs:isDefinedBy inspec: ;
-  rdfs:comment "This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-5."@en ;
+  rdfs:comment "This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the TE rules."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/skos-reference/> .
 
 inspec:SHACL a dct:Standard ;
   rdfs:label "SHACL"@en ;
   rdfs:isDefinedBy inspec: ;
-  rdfs:comment "This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the rules AP-1 — AP-16."@en ;
+  rdfs:comment "This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the AP rules."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/shacl> .
 
 inspec:SVG a dct:Standard ;
   rdfs:label "SVG"@en ;
   rdfs:isDefinedBy inspec: ;
-  rdfs:comment "This is a specification corresponding to a profile of SVG used to capture an expression of diagrams for interoperable specifications. Corresponds to the rules SVG-1 — SVG-5."@en ;
+  rdfs:comment "This is a specification corresponding to a profile of SVG used to capture an expression of diagrams for interoperable specifications. Corresponds to the SVG rules."@en ;
   rdfs:seeAlso <https://www.w3.org/TR/SVG11/> .
 
 inspec:variant a rdf:Property ;

--- a/docs/ap.md
+++ b/docs/ap.md
@@ -20,7 +20,7 @@ Let's clarify the words we are using in SHACL-INSPEC:
 
 ## Application Profile expression
 
-If you have not already, take a look at the [sixteen rules of SHACL-INSPEC](rules.md#rules-for-application-profiles---shacl-inspec).
+If you have not already, take a look at the [fifteen rules of SHACL-INSPEC](rules.md#rules-for-application-profiles---shacl-inspec).
 These rules may be a bit hard to take in, especially since SHACL is a complex language. Hence, below we list what is to be expected based on the application profile as a whole as well as on the shapes.
 
 First of all, for simplicity the requirement on multilinguality are not written explicitly below, i.e. labels, description / definition and usage note are all expected to be expressed with a language and potentially translated into several languages.
@@ -35,16 +35,13 @@ The following information MUST be provided for an application profile resource:
 * The application profile resource must have a stable identity in the form of a URI (subject position in triples)
 * The application profile resource must be typed as `prof:Profile`
 * A label expressed via the property `sh:name`
-* A list of public node shapes indicated via the property `dcterms:hasPart`
-* A list of public property shapes indicated via the property `dcterms:hasPart`
 
 The following information SHOULD/MAY be provided:
 
-* A list of all classes and properties used in the application profile, indicated via the properties `inspec:reuses` or `inspec:introduces`
 * A description / definition expressed via the property `sh:description`
 * A usage note expressed via the property `skos:scopeNote`
 * A reference to another application profile that expresses that it is a
-  * "subprofile" of another profile via `prof:isProfileOf`
+  * "subprofile" of another profile via `inspec:refines`
   * "variant of" another profile via the `inspec:variant`
 
 Note that for B being a subprofile of A:
@@ -53,6 +50,15 @@ Note that for B being a subprofile of A:
 * Data following application profile A will not always follow application profile B.
 
 Note also that the concepts of Application profiles being subprofiles and variant of each other of are exclusive since for the variant relation there is a requirement that at least one of the node shapes has to be a variant.
+
+### Interoperable specification resource
+
+The following information derived from the Application Profile MAY be provided for a profil interoperable specification resource:
+
+* A list of public node shapes in the application profile, indicated via the property `dcterms:hasPart`
+* A list of public property shapes in the application profile, indicated via the property `dcterms:hasPart`
+* A list of all classes and properties used in the application profile, indicated via the properties `inspec:reuses` or `inspec:introduces`
+* A relation, indicated via the `prof:isProfileOf` property, to any specification introducing an application profile for which there is a subprofile relation from the application profile
 
 ### Main and supportive node shapes
 

--- a/docs/bootstrapping.md
+++ b/docs/bootstrapping.md
@@ -10,23 +10,23 @@ inspec | <https://w3id.org/inspec/datavoc/>
 
 ## inspec:PROF
 
-This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules PROF-1 — PROF-10.
+This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the PROF rules.
 
 ## inspec:RDFS
 
-This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the rules DV-1 — DV-6.
+This is a specification corresponding to a profile of RDFS used to capture an expression of data vocabularies. Corresponds to the DV rules.
 
 ## inspec:SKOS
 
-This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the rules TE-1 — TE-5.
+This is a specification corresponding to a profile of SKOS used to capture an expression of terminologies. Corresponds to the TE rules.
 
 ## inspec:SHACL
 
-This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the rules AP-1 — AP-16.
+This is a specification corresponding to a profile of SHACL used to capture an expression of application profiles. Corresponds to the AP rules.
 
 ## inspec:SVG
 
-This is a specification corresponding to a profile of SVG used to capture an expression of diagrams for interoperable specifications. Corresponds to the rules SVG-1 — SVG-5.
+This is a specification corresponding to a profile of SVG used to capture an expression of diagrams for interoperable specifications. Corresponds to the SVG rules.
 
 ## inspec:UML_OSLO
 

--- a/docs/bootstrapping.md
+++ b/docs/bootstrapping.md
@@ -10,7 +10,7 @@ inspec | <https://w3id.org/inspec/datavoc/>
 
 ## inspec:PROF
 
-This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules INSPEC-1 — INSPEC-10.
+This is a specification corresponding to a profile of PROF used to capture an interoperable specification. Corresponds to the rules PROF-1 — PROF-10.
 
 ## inspec:RDFS
 

--- a/docs/example.md
+++ b/docs/example.md
@@ -78,21 +78,10 @@ ex:vi1 a prof:ResourceDescriptor ;
   prof:hasRole profrole:specification .
 ```
 
-The following triples can be provided as part of PROF-INSPEC, alternatively they can be auto generated as part of the harvesting process.
+The following triples may be provided as part of the enrichment described in [ENRICH-INSPEC](rules.md#rules-for-enriching-the-interoperable-specifications---enrich-inspec), and are expected to be auto generated as part of the harvesting process.
 
 ```turtle
-# referenced classes and properties - AP-16
-ex:spec1 inspec:reuses foaf:Document ;
-  inspec:reuses dcterms:title ;
-  inspec:reuses dcterms:created ;
-  inspec:reuses dcterms:publisher ;
-  inspec:reuses dcterms:subject ;
-  inspec:reuses foaf:Person ;
-  inspec:reuses foaf:name ;
-  inspec:reuses foaf:mbox ;
-  inspec:introduces ex:personNumber .
-
-# public shapes - generated as part of the harvesting process
+# public shapes - ENRICH-1
 ex:spec1 dcterms:hasPart ex:ns-document ;
   dcterms:hasPart ex:ps-title ;
   dcterms:hasPart ex:ps-created ;
@@ -102,6 +91,17 @@ ex:spec1 dcterms:hasPart ex:ns-document ;
   dcterms:hasPart ex:ps-name ;
   dcterms:hasPart ex:ps-mbox ;
   dcterms:hasPart ex:ps-pnr .
+
+# referenced classes and properties - ENRICH-2
+ex:spec1 inspec:reuses foaf:Document ;
+  inspec:reuses dcterms:title ;
+  inspec:reuses dcterms:created ;
+  inspec:reuses dcterms:publisher ;
+  inspec:reuses dcterms:subject ;
+  inspec:reuses foaf:Person ;
+  inspec:reuses foaf:name ;
+  inspec:reuses foaf:mbox ;
+  inspec:introduces ex:personNumber .
 ```
 
 ## RDFS-INSPEC expression

--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -1,10 +1,10 @@
 # Harvesting interoperable specifications
 
-The starting point when you harvest is an expression according to PROF-INSPEC, see rules INSPEC-1 - INSPEC-10.
+The starting point when you harvest is an expression according to PROF-INSPEC, see rules PROF-1 - PROF-10.
 
 ## Native harvesting according to INSPEC profile
 
-Below we will refer to the interoperable specification resource as INSPEC resource, see by INSPEC-1 what we require of it.
+Below we will refer to the interoperable specification resource as INSPEC resource, see by PROF-1 what we require of it.
 
 ### Data vocabulary
 

--- a/docs/harvesting.md
+++ b/docs/harvesting.md
@@ -10,7 +10,7 @@ Below we will refer to the interoperable specification resource as INSPEC resour
 
 If the data vocabulary is reused, i.e. `prof:isInheritedFrom` is provided, no loading is done. If the referenced interoperable specification does not exist already in the system a warning is logged.
 
-If the data vocabulary is not reused it is attempted to be retrieved from either the `prof:hasArtifact` value or the subject. The retrieved RDF datasource is checked against RDFS-INSPEC before being loaded into the triplestore. All classes and properties should be available in the triplestore. The ontology resource should also be available for easy access in the triplestore and also pointed to via `dcterms:subject` from the corresponding `prof:ResourceDescriptor`. (The classes and properties will only be pointed to via the `inspec:reuses` or `inspec:introduces` properties from the INSPEC resource if they are explicitly used as indicated in the application profile, see below.)
+If the data vocabulary is not reused it is attempted to be retrieved from either the `prof:hasArtifact` value or the subject. The retrieved RDF datasource is checked against RDFS-INSPEC before being loaded into the triplestore. All classes and properties should be available in the triplestore. The ontology resource should also be available for easy access in the triplestore and also pointed to via `dcterms:subject` from the corresponding `prof:ResourceDescriptor`. (The classes and properties will only be pointed to via the `inspec:reuses` or `inspec:introduces` properties from the INSPEC resource if they are explicitly used as indicated in the application profile, see below, or if the specification is a foundational interoperable specification introducing the data vocabulary.)
 
 ### Terminology
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -14,25 +14,25 @@ The rules for interoperable specifications are divided into five parts:
 
 For a specification to be considered a interoperable specification the following must apply:
 
-><span id="inspec1"></span> **Rule INSPEC-1:** The "interoperable specification resource" and its parts MUST have URIs and be described with PROF, the interoperable specification resource MUST be typed as `prof:Profile` or `dcterms:Standard` and have a `dcterms:conformsTo` point to `inspec:PROF`
+><span id="prof1"></span> **Rule PROF-1:** The "interoperable specification resource" and its parts MUST have URIs and be described with PROF, the interoperable specification resource MUST be typed as `prof:Profile` or `dcterms:Standard` and have a `dcterms:conformsTo` point to `inspec:PROF`
 
-><span id="inspec2"></span> **Rule INSPEC-2:** All specification parts MUST be indicated via the `prof:hasResource` property from the interoperable specification and be typed as `prof:ResourceDescriptor`. An interoperable specification part MAY be a data vocabulary, a terminology, an application profile or a diagram. Other parts may exist but have no prescribed meaning by the interoperable specification profile.
+><span id="prof2"></span> **Rule PROF-2:** All specification parts MUST be indicated via the `prof:hasResource` property from the interoperable specification and be typed as `prof:ResourceDescriptor`. An interoperable specification part MAY be a data vocabulary, a terminology, an application profile or a diagram. Other parts may exist but have no prescribed meaning by the interoperable specification profile.
 
-><span id="inspec3"></span> **Rule INSPEC-3:** Each data vocabulary MUST be detected by `dcterms:conformsTo` pointing to `inspec:RDFS` and MUST be possible to interpret as RDFS-INSPEC.
+><span id="prof3"></span> **Rule PROF-3:** Each data vocabulary MUST be detected by `dcterms:conformsTo` pointing to `inspec:RDFS` and MUST be possible to interpret as RDFS-INSPEC.
 
-><span id="inspec4"></span> **Rule INSPEC-4:** Each terminology MUST be detected by `dcterms:conformsTo` pointing to `inspec:SKOS` and MUST be possible to interpret as SKOS-INSPEC.
+><span id="prof4"></span> **Rule PROF-4:** Each terminology MUST be detected by `dcterms:conformsTo` pointing to `inspec:SKOS` and MUST be possible to interpret as SKOS-INSPEC.
 
-><span id="inspec5"></span> **Rule INSPEC-5:** Each application profile MUST be detected by `dcterms:conformsTo` pointing to `inspec:SHACL` and MUST be possible to interpret as SHACL-INSPEC
+><span id="prof5"></span> **Rule PROF-5:** Each application profile MUST be detected by `dcterms:conformsTo` pointing to `inspec:SHACL` and MUST be possible to interpret as SHACL-INSPEC
 
-><span id="inspec6"></span> **Rule INSPEC-6:** A diagram MUST be detected by `dcterms:conformsTo` property pointing to `inspec:SVG` and MUST follow SVG-INSPEC
+><span id="prof6"></span> **Rule PROF-6:** A diagram MUST be detected by `dcterms:conformsTo` property pointing to `inspec:SVG` and MUST follow SVG-INSPEC
 
-><span id="inspec7"></span> **Rule INSPEC-7:** A **foundational** interoperable specification MUST contain at least one data vocabulary or one terminology, MUST NOT contain an application profile and MUST be typed as `dcterms:Standard`
+><span id="prof7"></span> **Rule PROF-7:** A **foundational** interoperable specification MUST contain at least one data vocabulary or one terminology, MUST NOT contain an application profile and MUST be typed as `dcterms:Standard`
 
-><span id="inspec8"></span> **Rule INSPEC-8:** A **profile** interoperable specification MUST contain at least one application profile and MUST be typed as `prof:Profile`
+><span id="prof8"></span> **Rule PROF-8:** A **profile** interoperable specification MUST contain at least one application profile and MUST be typed as `prof:Profile`
 
-><span id="inspec9"></span> **Rule INSPEC-9:** A profile interoperable specification MUST list all data vocabularies and terminologies it **uses** in the application profile explicitly as interoperable specification parts
+><span id="prof9"></span> **Rule PROF-9:** A profile interoperable specification MUST list all data vocabularies and terminologies it **uses** in the application profile explicitly as interoperable specification parts
 
-><span id="inspec10"></span> **Rule INSPEC-10:** Interoperable specification parts that are **reused** (as opposed to **introduced**) SHOULD indicate that by referring to the interoperable specification where they where introduced via the `prof:isInheritedFrom` property
+><span id="prof10"></span> **Rule PROF-10:** Interoperable specification parts that are **reused** (as opposed to **introduced**) SHOULD indicate that by referring to the interoperable specification where they where introduced via the `prof:isInheritedFrom` property
 
 ## Rules for data vocabularies - RDFS-INSPEC
 
@@ -48,7 +48,7 @@ RDFS-INSPEC builds on top of the RDF Schema specification by providing the follo
 
 ><span id="dv5"></span> **Rule DV-5:** Classes and properties from other vocabularies MAY be included in the RDF Dataset, e.g. when being pointed to via `rdfs:subClassOf` and `rdfs:subProperty`, but MUST NOT point to the same "data vocabulary resource" via the `rdfs:isDefinedBy` property
 
-><span id="dv6"></span> **Rule DV-6:** The "data vocabulary resource" MUST be indicated via the `dcterms:subject` property from the "interoperable specification part" (introduced in Rule INSPEC-2).
+><span id="dv6"></span> **Rule DV-6:** The "data vocabulary resource" MUST be indicated via the `dcterms:subject` property from the "interoperable specification part" (introduced in Rule PROF-2).
 
 ## Rules for terminologies - SKOS-INSPEC
 
@@ -62,7 +62,7 @@ SKOS-INSPEC builds on top of the SKOS specification by providing the following a
 
 ><span id="te4"></span> **Rule TE-4:** All concepts, collections as well as the terminology resource MUST have URIs
 
-><span id="te5"></span> **Rule TE-5:** The "terminology resource" MUST be indicated via the `dcterms:subject` property from the "interoperable specification part" (introduced in Rule INSPEC-2).
+><span id="te5"></span> **Rule TE-5:** The "terminology resource" MUST be indicated via the `dcterms:subject` property from the "interoperable specification part" (introduced in Rule PROF-2).
 
 ## Rules for application profiles - SHACL-INSPEC
 
@@ -70,7 +70,7 @@ SHACL-INSPEC builds on top of the SHACL specification by providing additional re
 
 ><span id="ap1"></span> **Rule AP-1:** An application profile MUST be expressed in a single RDF Dataset<sup><a href="#fn2" id="fn2_1">[2]</a></sup>
 
-><span id="ap2"></span> **Rule AP-2:** There MUST be a single "application profile resource" with a URI in the RDF Dataset AND it MUST be the same as the "interoperable specification resource" (introduced in Rule INSPEC-1)
+><span id="ap2"></span> **Rule AP-2:** There MUST be a single "application profile resource" with a URI in the RDF Dataset AND it MUST be the same as the "interoperable specification resource" (introduced in Rule PROF-1)
 
 ><span id="ap3"></span> **Rule AP-3:** All property shapes with a severity of `sh:Violation` and with at least one constraint (`sh:and` for specialization does not count) are considered **public** and they MUST have URIs
 
@@ -98,7 +98,7 @@ SHACL-INSPEC builds on top of the SHACL specification by providing additional re
 
 ><span id="ap15"></span> **Rule AP-15:** Shapes from other application profiles used for refinement or for variants MAY be included in the RDF Dataset but MUST NOT point to the same "application profile resource" via the `rdfs:isDefinedBy` property
 
-><span id="ap16"></span> **Rule AP-16:** All classes and properties referred to via shapes SHOULD be explicitly indicated from the "application profile resource". The indication should use `inspec:reuses` if the referred resource is part of a **reused** specification part (see Rule INSPEC-10), otherwise `inspec:introduces` should be used.
+><span id="ap16"></span> **Rule AP-16:** All classes and properties referred to via shapes SHOULD be explicitly indicated from the "application profile resource". The indication should use `inspec:reuses` if the referred resource is part of a **reused** specification part (see Rule PROF-10), otherwise `inspec:introduces` should be used.
 
 ## Rules for diagrams - SVG-INSPEC
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,12 +1,13 @@
 # Rules for interoperable specifications
 
-The rules for interoperable specifications are divided into five parts:
+The rules for interoperable specifications are divided into six parts. The first five apply to anyone creating or distributing an interoperable specification, the last one applies mainly to actors harvesting interoperable specifications:
 
 1. Rules for interoperable specifications - PROF-INSPEC - based on [[[DX-PROF]]]
 2. Rules for data vocabularies - RDFS-INSPEC - based on [[[RDF-SCHEMA]]]
-3. Rules for terminologies - SKOS-INSPEC - based on [[[SKOS-REFERENCE]]]]
+3. Rules for terminologies - SKOS-INSPEC - based on [[[SKOS-REFERENCE]]]
 4. Rules for application profiles - SHACL-INSPEC - based on [[[SHACL]]]
-5. Rules for diagrams - SVG-INSPEC - based on  [[[SVG11]]]
+5. Rules for diagrams - SVG-INSPEC - based on [[[SVG11]]]
+6. Rules for enriching the interoperable specifications - ENRICH-INSPEC
 
 ## Rules for interoperable specifications - PROF-INSPEC
 
@@ -98,7 +99,6 @@ SHACL-INSPEC builds on top of the SHACL specification by providing additional re
 
 ><span id="ap15"></span> **Rule AP-15:** Shapes from other application profiles used for refinement or for variants MAY be included in the RDF Dataset but MUST NOT point to the same "application profile resource" via the `rdfs:isDefinedBy` property
 
-><span id="ap16"></span> **Rule AP-16:** All classes and properties referred to via shapes SHOULD be explicitly indicated from the "application profile resource". The indication should use `inspec:reuses` if the referred resource is part of a **reused** specification part (see Rule PROF-10), otherwise `inspec:introduces` should be used.
 
 ## Rules for diagrams - SVG-INSPEC
 
@@ -113,6 +113,18 @@ SVG-INSPEC builds on top of SVG to provide a way to clarify whether objects in a
 ><span id="svg4"></span> **Rule SVG-4:** An element with type node-shape or property-shape MAY have a custom data attribute on the form `data-inspec-public="true"` if it is public according to rule AP-3 or AP-4.
 
 ><span id="svg5"></span> **Rule SVG-5:** An element with type node-shape that is also public MAY have a custom data attribute on the form `data-inspec-weight="WEIGHT"` where WEIGHT is either "main" or "supportive" according to rule AP-5.
+
+## Rules for enriching the interoperable specifications - ENRICH-INSPEC
+
+This set of rules aim to enrich the interoperable specification by analysing the contents of, and interaction between, the different interoperable specification parts in order to surface information which may be valuable for a webb of interoperable specifications.
+
+><span id="enrich1"></span> **Rule ENRICH-1:** Every public property or node shape MAY be pointed to from the "interoperable specification resource" (introduced in Rule PROF-1) via the `dcterms:hasPart` property.
+
+><span id="enrich2"></span> **Rule ENRICH-2:** For a profile interoperable specification all classes and properties referred to via shapes MAY be explicitly indicated from the "interoperable specification resource". The indication SHOULD use `inspec:reuses` if the referred resource is part of a **reused** specification part (see Rule PROF-10), otherwise `inspec:introduces` SHOULD be used.
+
+><span id="enrich3"></span> **Rule ENRICH-3:** For a foundational interoperable specification all classes and properties defined by (see Rule DV-3) an **introduced** data vocabulary MAY be explicitly indicated from the "interoperable specification resource" using `inspec:introduces`.
+
+><span id="enrich4"></span> **Rule ENRICH-4:** If a `inspec:refines` relation is present in the application profile resource the specification introducing the refined application MAY be indicated from the "interoperable specification resource" using `prof:isProfileOf`.
 
 <section id="footnotes" style="font-size:smaller;border-top:1px solid" class="informative">
 <ol>


### PR DESCRIPTION
# Pull Request Description

* Moves dcterms:hasPart (previously in AP-3/AP-4) to ENRICH-1
* Moves AP-16 to ENRICH-2, and changes these be added to the specification resource
* Adds ENRICH-3, a complement to ENRICH-2 for foundational specifications
* Adds ENRICH-4, indicating how prof:isProfileOf can be inferred from AP

Also some cleanup in ap.md related to previous changes to AP rules

Builds on #57

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
