### PR TITLE
clarify that exclusive or in PROF-1

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -15,7 +15,7 @@ The rules for interoperable specifications are divided into six parts. The first
 
 For a specification to be considered a interoperable specification the following must apply:
 
-><span id="prof1"></span> **Rule PROF-1:** The "interoperable specification resource" and its parts MUST have URIs and be described with PROF, the interoperable specification resource MUST be typed as `prof:Profile` or `dcterms:Standard` and have a `dcterms:conformsTo` point to `inspec:PROF`
+><span id="prof1"></span> **Rule PROF-1:** The "interoperable specification resource" and its parts MUST have URIs and be described with PROF, the interoperable specification resource MUST be typed as exactly one of `prof:Profile` or `dcterms:Standard` and have a `dcterms:conformsTo` point to `inspec:PROF`
 
 ><span id="prof2"></span> **Rule PROF-2:** All specification parts MUST be indicated via the `prof:hasResource` property from the interoperable specification and be typed as `prof:ResourceDescriptor`. An interoperable specification part MAY be a data vocabulary, a terminology, an application profile or a diagram. Other parts may exist but have no prescribed meaning by the interoperable specification profile.
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -15,7 +15,7 @@ The rules for interoperable specifications are divided into six parts. The first
 
 For a specification to be considered a interoperable specification the following must apply:
 
-><span id="prof1"></span> **Rule PROF-1:** The "interoperable specification resource" and its parts MUST have URIs and be described with PROF, the interoperable specification resource MUST be typed as exactly one of `prof:Profile` or `dcterms:Standard` and have a `dcterms:conformsTo` point to `inspec:PROF`
+><span id="prof1"></span> **Rule PROF-1:** The "interoperable specification resource" and its parts MUST have URIs and be described with PROF, the interoperable specification resource MUST be typed either as `prof:Profile` (superclass `dcterms:Standard` is implicit) or only as `dcterms:Standard`, and have a `dcterms:conformsTo` point to `inspec:PROF`
 
 ><span id="prof2"></span> **Rule PROF-2:** All specification parts MUST be indicated via the `prof:hasResource` property from the interoperable specification and be typed as `prof:ResourceDescriptor`. An interoperable specification part MAY be a data vocabulary, a terminology, an application profile or a diagram. Other parts may exist but have no prescribed meaning by the interoperable specification profile.
 


### PR DESCRIPTION
# Pull Request Description

INSPEC-7/8 cannot both be satisified hence an interoperable specification cannot be typed as both dcterms:Standard and prof:Profile. "or" is however inclusive so clarify that it is intended to be exclusive.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
