### PR TITLE
Use sh:hasValue rather than sh:in for rdf:type and exemplify main/supportive

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -158,13 +158,13 @@ dtheme: a skos:ConceptScheme ;
 ex:spec1 a owl:Ontology;
   owl:imports sh: .
 
-# --------Document shape----------
+# --------Document shape (main)----------
 ex:ns-document a sh:NodeShape ;
   sh:targetClass foaf:Document ;
   sh:name "Document"@en ;
   sh:property [
       sh:path rdf:type ;
-      sh:in ( foaf:Document ) ;
+      sh:hasValue foaf:Document ;
     ],
     ex:ps-title,
     ex:ps-created,
@@ -213,13 +213,12 @@ ex:ps-subject a sh:PropertyShape ;
   ] ;
   rdfs:isDefinedBy ex:spec1 .
 
-# --------Person shape----------
+# --------Person shape (supportive)----------
 ex:ns-person a sh:NodeShape ;
-  sh:targetClass foaf:Person ;
   sh:name "Person"@en ;
   sh:property [
       sh:path rdf:type ;
-      sh:in ( foaf:Person ) ;
+      sh:hasValue foaf:Person ;
     ],
     ex:ps-name,
     ex:ps-mbox,


### PR DESCRIPTION
Use sh:hasValue rather than sh:in for rdf:type and exemplify main/supportive

`sh:hasValue` is more appropriate than `sh:in` for r`df:type` on NodeShapes.

Also drop the `sh:targetClass` on one of the node types to exemplify main/supportive node shapes and thereby the need for a `sh:property` statement for `rdf:type`.

Fixes #63

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
